### PR TITLE
Also check for m-suffixed python include folder

### DIFF
--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -547,7 +547,13 @@ local rule compute-default-paths ( target-os : version ? : prefix ? :
     }
     else
     {
-        includes ?= $(prefix)/include/python$(version) ;
+        local default-include-path = $(prefix)/include/python$(version) ;
+        if ! [ path.exists $(default-include-path) ] && [ path.exists $(default-include-path)m ]
+        {
+            default-include-path = $(default-include-path)m ;
+        }
+
+        includes ?= $(default-include-path) ;
 
         local lib = $(exec-prefix)/lib ;
         libraries ?= $(lib)/python$(version)/config $(lib) ;


### PR DESCRIPTION
## Proposed changes

The python include path is often suffixed with a letter, most commonly `m` which leads to B2 not correctly determining the default include path. This change checks for that folder and uses it if the non-suffixed one does not exist.

This fixes a major pain point, see https://github.com/boostorg/build/issues/633, https://github.com/boostorg/build/issues/443 https://github.com/boostorg/build/issues/289

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [x] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [x] I added necessary documentation (if appropriate)

## Further comments

A better solution is likely to use `python -c "from sysconfig import get_paths as gp; print(gp()['include'])"` as the default include path. However that is above my level of B2 expertise, so I added the current change only which should work in 99% of the cases.
