### PR TITLE
Reenable ability of generators to return property-set as first item

### DIFF
--- a/src/build/generators.jam
+++ b/src/build/generators.jam
@@ -475,7 +475,13 @@ class generator
         }
         if $(result)
         {
-            return $(relevant) $(result) ;
+            if [ class.is-a $(result[1]) : property-set ]
+            {
+                return [ $(result[1]).add $(relevant) ] $(result[2-]) ;
+            }
+            else {
+               return $(relevant) $(result) ;
+            }
         }
     }
 


### PR DESCRIPTION
- Fixes issue introduced in https://github.com/bfgroup/b2/commit/ee613a6a289934181bcfb69c881864bf2d2f385f (feature relevance)

## Proposed changes

Re-introduces functionality that was present in B2, but removed when the "<relevant>" feature was introduced 
Previously, generators could return a property-set as the first item in the result list, this feature removed that. It doesn't seem clear to me that removing this functionality was intentional or necessary to make the <relevant> feature work. I suspect it was overlooked because the built-in generators did not utilize this functionality that the system supported

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] N/A -- I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

This functionality was relied upon in the https://github.com/wix-incubator/Boost.Build.XModule library which worked with older versions of boost.build. I imagine there might be others who have written generators that rely on this same functionality.

All tests via 'python test_all.py' pass except for 'pch' (which fails on my system with or without this change)
