### PR TITLE
.vscode/tasks.json: Fix working directory location for build tasks

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
                 "command": "./build.sh"
             },
             "options": {
-                "cwd": "src/engine"
+                "cwd": "${workspaceFolder}/src/engine"
             },
             "problemMatcher": {
                 "owner": "cpptools",
@@ -42,7 +42,7 @@
                 "command": "CXX='infer run -- clang++' ./build.sh clang"
             },
             "options": {
-                "cwd": "src/engine"
+                "cwd": "${workspaceFolder}/src/engine"
             },
             "problemMatcher": {
                 "owner": "cpptools",


### PR DESCRIPTION
## Proposed changes

Apparently, neither `src/engine` nor `./src/engine` is taken as relative path
by VS Code and leads to task failure:

```
Executing task: ./build.sh
The terminal process failed to launch: Starting directory (cwd) /src/engine does not exist.
```

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

n/a