### PR TITLE
Handle spaces in CXX path in config_toolset.bat

### DIFF
--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -34,7 +34,7 @@ call :Call_If_Exists "%B2_TOOLSET_ROOT%bin\VCVARS32.BAT"
 if not "_%B2_TOOLSET_ROOT%_" == "__" (
     set "PATH=%B2_TOOLSET_ROOT%bin;%PATH%"
     )
-set "B2_CXX=%CXX% /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
+set "B2_CXX="%CXX%" /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof
@@ -49,7 +49,7 @@ if NOT "_%B2_TOOLSET_ROOT%_" == "__" (
     if "_%VCINSTALLDIR%_" == "__" (
         set "PATH=%B2_TOOLSET_ROOT%bin;%PATH%"
         ) )
-set "B2_CXX=%CXX% /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
+set "B2_CXX="%CXX%" /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof
@@ -68,7 +68,7 @@ if NOT "_%B2_TOOLSET_ROOT%_" == "__" (
     if "_%VCINSTALLDIR%_" == "__" (
         set "PATH=%B2_TOOLSET_ROOT%bin;%PATH%"
         ) )
-set "B2_CXX=%CXX% /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
+set "B2_CXX="%CXX%" /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof
@@ -88,7 +88,7 @@ if NOT "_%B2_TOOLSET_ROOT%_" == "__" (
     if "_%VCINSTALLDIR%_" == "__" (
         set "PATH=%B2_TOOLSET_ROOT%bin;%PATH%"
         ) )
-set "B2_CXX=%CXX% /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
+set "B2_CXX="%CXX%" /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof
@@ -110,7 +110,7 @@ REM return to current directory as vsdevcmd_end.bat switches to %USERPROFILE%\So
 pushd %CD%
 if "_%VSINSTALLDIR%_" == "__" call :Call_If_Exists "%B2_TOOLSET_ROOT%Auxiliary\Build\vcvarsall.bat" %B2_BUILD_ARGS%
 popd
-set "B2_CXX=%CXX% /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
+set "B2_CXX="%CXX%" /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof
@@ -132,7 +132,7 @@ REM return to current directory as vsdevcmd_end.bat switches to %USERPROFILE%\So
 pushd %CD%
 if "_%VSINSTALLDIR%_" == "__" call :Call_If_Exists "%B2_TOOLSET_ROOT%Auxiliary\Build\vcvarsall.bat" %B2_BUILD_ARGS%
 popd
-set "B2_CXX=%CXX% /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
+set "B2_CXX="%CXX%" /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof
@@ -154,7 +154,7 @@ REM return to current directory as vsdevcmd_end.bat switches to %USERPROFILE%\So
 pushd %CD%
 if "_%VSINSTALLDIR%_" == "__" call :Call_If_Exists "%B2_TOOLSET_ROOT%Auxiliary\Build\vcvarsall.bat" %B2_BUILD_ARGS%
 popd
-set "B2_CXX=%CXX% /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
+set "B2_CXX="%CXX%" /nologo /MP /MT /TP /Feb2 /wd4996 /O2 /GL /EHsc"
 set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
 set "_known_=1"
 goto :eof
@@ -170,37 +170,37 @@ if "_%B2_TOOLSET_ROOT%_" == "__" (
 if not "_%B2_TOOLSET_ROOT%_" == "__" (
     set "PATH=%B2_TOOLSET_ROOT%Bin;%PATH%"
     )
-set "B2_CXX=%CXX% -tC -P -O2 -w- -I"%B2_TOOLSET_ROOT%Include" -L"%B2_TOOLSET_ROOT%Lib" -eb2"
+set "B2_CXX="%CXX%" -tC -P -O2 -w- -I"%B2_TOOLSET_ROOT%Include" -L"%B2_TOOLSET_ROOT%Lib" -eb2"
 set "_known_=1"
 goto :eof
 
 :Config_COMO
 if not defined CXX ( set "CXX=como" )
-set "B2_CXX=%CXX% --inlining -o b2.exe"
+set "B2_CXX="%CXX%" --inlining -o b2.exe"
 set "_known_=1"
 goto :eof
 
 :Config_GCC
 if not defined CXX ( set "CXX=g++" )
-set "B2_CXX=%CXX% -x c++ -std=c++11 -s -O3 -o b2.exe"
+set "B2_CXX="%CXX%" -x c++ -std=c++11 -s -O3 -o b2.exe"
 set "_known_=1"
 goto :eof
 
 :Config_CLANG
 if not defined CXX ( set "CXX=clang++" )
-set "B2_CXX=%CXX% -x c++ -std=c++11 -s -O3 -o b2.exe"
+set "B2_CXX="%CXX%" -x c++ -std=c++11 -s -O3 -o b2.exe"
 set "_known_=1"
 goto :eof
 
 :Config_GCC_NOCYGWIN
 if not defined CXX ( set "CXX=g++" )
-set "B2_CXX=%CXX% -x c++ -std=c++11 -s -O3 -mno-cygwin -o b2.exe"
+set "B2_CXX="%CXX%" -x c++ -std=c++11 -s -O3 -mno-cygwin -o b2.exe"
 set "_known_=1"
 goto :eof
 
 :Config_INTEL_WIN32
 if not defined CXX ( set "CXX=icl" )
-set "B2_CXX=%CXX% /nologo /MT /O2 /Ob2 /Gy /GF /GA /GB /Feb2"
+set "B2_CXX="%CXX%" /nologo /MT /O2 /Ob2 /Gy /GF /GA /GB /Feb2"
 set "_known_=1"
 goto :eof
 
@@ -210,6 +210,6 @@ if not "_%B2_TOOLSET_ROOT%_" == "__" (
     set "PATH=%B2_TOOLSET_ROOT%bin;%PATH%"
     )
 for /F "delims=" %%I in ("%CXX%") do set "PATH=%PATH%;%%~dpI"
-set "B2_CXX=%CXX% -x c++ -std=c++11 -s -O3 -o b2.exe"
+set "B2_CXX="%CXX%" -x c++ -std=c++11 -s -O3 -o b2.exe"
 set "_known_=1"
 goto :eof


### PR DESCRIPTION
Surround the `CXX` path with double quotes to support spaces in the path.
Otherwise if the `CXX` variable is set to a path containing spaces like

```
C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Tools/MSVC/14.16.27023/bin/Hostx64/x64/cl.exe
```

the following error message is printed:

```
'C:/Program' is not recognized as an internal or external command,
operable program or batch file.
```

---

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [ ] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [ ] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [X] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)
