### PR TITLE
moved aix pthread arg

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -157,6 +157,8 @@ check_toolset ()
     if test_toolset clang && test_uname Darwin && test_compiler clang++ -x c++ -std=c++11 ; then B2_TOOLSET=clang ; return ${TRUE} ; fi
     # GCC (gcc)..
     if test_toolset gcc && test_compiler g++ -x c++ -std=c++11 ; then B2_TOOLSET=gcc ; return ${TRUE} ; fi
+    # GCC (gcc) with -pthread arg (for AIX)..
+    if test_toolset gcc && test_compiler g++ -x c++ -std=c++11 -pthread ; then B2_TOOLSET=gcc ; return ${TRUE} ; fi
     # Clang (clang)..
     if test_toolset clang && test_compiler clang++ -x c++ -std=c++11 ; then B2_TOOLSET=clang ; return ${TRUE} ; fi
     # Intel macOS (intel-darwin)
@@ -312,19 +314,6 @@ case "${B2_TOOLSET}" in
 
     gcc)
         CXX_VERSION_OPT=${CXX_VERSION_OPT:---version}
-        # Check for machine specific options.
-        machine=$(${B2_CXX} -dumpmachine 2>/dev/null)
-        if test $? -ne 0 ; then
-            echo "B2_TOOLSET is gcc, but the 'gcc' command cannot be executed."
-            echo "Make sure 'gcc' is in PATH, or use a different toolset."
-            exit 1
-        fi
-        case $machine in
-            *ibm-aix*)
-            # AIX needs threading option to use std::thread, it seems.
-            B2_CXX="${B2_CXX} -pthread"
-            ;;
-        esac
         B2_CXXFLAGS_RELEASE="-O2 -s"
         B2_CXXFLAGS_DEBUG="-O0 -g"
     ;;


### PR DESCRIPTION
## Proposed changes

Bugfix for building on AIX. Noticed when trying to upgrade from boost-1.74.0 to boost-1.76.0 on AIX.
Previously when it was still allowed to pass args via CXXFLAGS we added the "-pthread" argument via that environment variable. Now that the contents of that env var gets ignored the build failed, so I investigated whats needed to get that built again. I noticed that there is already some handling regarding "-pthread" in the scripts.

While the "-pthread" arg gets added to the build of b2 itself (as the comment there says it is needed for using std::thread) it did not get added to the build of check_cxx11.cpp before that, which also uses std::thread. I.e. the check if a working compiler is present fails and it will not reach the place where "-pthread" gets added to the flags.

This change moves the place where "-pthread" gets added to before check_cpp11.cpp gets compiled.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [ ] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
