### PR TITLE
Add default value for cxx and cxxflags options for the cxx toolset

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -284,13 +284,9 @@ fi
 
 # If we have B2_TOOLSET=cxx but no B2_CXX_OPT nor B2_CXXFLAGS_OPT specified by the user
 # we assume they meant $CXX and $CXXFLAGS.
-if test "${B2_TOOLSET}" = "cxx" ; then
-    if test "${B2_CXX_OPT}" = "" ; then
-        B2_CXX_OPT="${CXX}"
-    fi
-    if test "${B2_CXXFLAGS_OPT}" = "" ; then
-        B2_CXXFLAGS_OPT="${CXXFLAGS}"
-    fi
+if test "${B2_TOOLSET}" = "cxx" -a "${B2_CXX_OPT}" = "" -a "${B2_CXXFLAGS_OPT}" = "" ; then
+    B2_CXX_OPT="${CXX}"
+    B2_CXXFLAGS_OPT="${CXXFLAGS}"
 fi
 
 # Guess toolset, or toolset commands.

--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -276,10 +276,21 @@ if test_true ${B2_HELP_OPT} ; then
     error_exit
 fi
 
-# If we have a CXX but no B2_TOLSET specified by the user we assume they meant
+# If we have a CXX but no B2_TOOLSET specified by the user we assume they meant
 # "cxx" as the toolset.
 if test "${B2_CXX_OPT}" != "" -a "${B2_TOOLSET}" = "" ; then
     B2_TOOLSET=cxx
+fi
+
+# If we have B2_TOOLSET=cxx but no B2_CXX_OPT nor B2_CXXFLAGS_OPT specified by the user
+# we assume they meant $CXX and $CXXFLAGS.
+if test "${B2_TOOLSET}" = "cxx" ; then
+    if test "${B2_CXX_OPT}" = "" ; then
+        B2_CXX_OPT="${CXX}"
+    fi
+    if test "${B2_CXXFLAGS_OPT}" = "" ; then
+        B2_CXXFLAGS_OPT="${CXXFLAGS}"
+    fi
 fi
 
 # Guess toolset, or toolset commands.


### PR DESCRIPTION
## Proposed changes

As discussed on [slack](https://cpplang.slack.com/archives/C27KZLB0X/p1619028622427200), this PR adds default values for `--cxx` and `--cxxflags` options for the `cxx`  toolset: 

```
--cxx=[$CXX]
--cxxflag=[$CXXFLAGS]
```

This allows to run `./bootstrap.sh --with-toolset=cxx` and get what I think is the expected behavior.

## Types of changes

Set default value of program options from envvars.

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [ ] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [ ] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)
