### PR TITLE
Set macOS default-toolset to clang-darwin

### DIFF
--- a/src/build-system.jam
+++ b/src/build-system.jam
@@ -644,7 +644,7 @@ local rule should-clean-project ( project )
             }
             else if [ os.name ] = MACOSX
             {
-                default-toolset = darwin ;
+                default-toolset = clang ;
             }
         }
 


### PR DESCRIPTION
## Proposed changes

On macOS, it seems strange to default to gcc, considering most users won't have it installed. It appears this works any way because Xcode and command-line tools bundle some sort of gcc aliases.

In downstream Nix on macOS, builds are largely isolated from the system, and these aliases are not available, so b2's default selection fails. I've added this change downstream: https://github.com/NixOS/nixpkgs/pull/122581

I'm a little worried that merging this here is a breaking change, though, because it's swapping a default for all users. I'm also wondering if the better fix would be to modify `darwin.jam` instead.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [x] Other (please describe): Change to defaults

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)