### PR TITLE
clang-linux cleanup

### DIFF
--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -181,14 +181,12 @@ actions compile.c bind PCH_FILE
 ###############################################################################
 # PCH emission
 
-RM = [ common.rm-command ] ;
-
 rule compile.c++.pch ( targets * : sources * : properties * ) {
 }
 
 actions compile.c++.pch
 {
-  $(RM) -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -Xclang -emit-pch -o "$(<)" "$(>)"
+  "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -Xclang -emit-pch -o "$(<)" "$(>)"
 }
 
 rule compile.c.pch ( targets * : sources * : properties * ) {
@@ -196,7 +194,7 @@ rule compile.c.pch ( targets * : sources * : properties * ) {
 
 actions compile.c.pch
 {
-  $(RM) -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -Xclang -emit-pch -o "$(<)" "$(>)"
+  "$(CONFIG_COMMAND)" -c -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -Xclang -emit-pch -o "$(<)" "$(>)"
 }
 
 ###############################################################################

--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -157,6 +157,8 @@ toolset.flags clang-linux RESPONSE_FILE_SUB <response-file>auto : a ;
 toolset.flags clang-linux RESPONSE_FILE_SUB <response-file>file : f ;
 toolset.flags clang-linux RESPONSE_FILE_SUB <response-file>contents : c ;
 
+# Used in actions for multi argument options
+_ = " " ;
 ###############################################################################
 # C and C++ compilation
 
@@ -229,14 +231,6 @@ actions compile.c.pch
 
 local soname-os = [ set.difference $(all-os) : windows ] ;
 toolset.flags clang-linux.link SONAME_OPT <target-os>$(soname-os) : "-Wl,-soname -Wl," ;
-
-rule link ( targets * : sources * : properties * ) {
-  _ on $(targets) = " " ;
-}
-
-rule link.dll ( targets * : sources * : properties * ) {
-  _ on $(targets) = " " ;
-}
 
 actions link bind LIBRARIES {
     "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -o "$(<)" @($(<[1]:T).rsp:O=FC:<=@":>=":E=-Wl,-R$(_)-Wl,"$(RPATH)" -Wl,-rpath-link$(_)-Wl,"$(RPATH_LINK)" $(START-GROUP) "$(>:T)" "$(LIBRARIES:T)" $(FINDLIBS-ST-PFX:T) -l$(FINDLIBS-ST:T) $(FINDLIBS-SA-PFX:T) -l$(FINDLIBS-SA:T) $(END-GROUP)) $(OPTIONS) $(USER_OPTIONS)

--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -36,9 +36,6 @@ generators.override clang-linux.searched-lib-generator : searched-lib-generator 
 generators.override clang-linux.compile.c.pch   : pch.default-c-pch-generator   ;
 generators.override clang-linux.compile.c++.pch : pch.default-cpp-pch-generator ;
 
-type.set-generated-target-suffix PCH
-  : <toolset>clang <toolset-clang:platform>linux : pth ;
-
 toolset.inherit-rules clang-linux : gcc ;
 toolset.inherit-flags clang-linux : gcc
   : <inlining>full

--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -181,15 +181,9 @@ actions compile.c bind PCH_FILE
 ###############################################################################
 # PCH emission
 
-rule compile.c++.pch ( targets * : sources * : properties * ) {
-}
-
 actions compile.c++.pch
 {
   "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -Xclang -emit-pch -o "$(<)" "$(>)"
-}
-
-rule compile.c.pch ( targets * : sources * : properties * ) {
 }
 
 actions compile.c.pch

--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -163,47 +163,22 @@ _ = " " ;
 # C and C++ compilation
 
 rule compile.c++ ( targets * : sources * : properties * ) {
-  local pch-file = [ on $(<) return $(PCH_FILE) ] ;
-
-  if $(pch-file) {
-    DEPENDS $(<) : $(pch-file) ;
-    clang-linux.compile.c++.with-pch $(targets) : $(sources) ;
-  }
-  else {
-    clang-linux.compile.c++.without-pch $(targets) : $(sources) ;
-  }
+  DEPENDS $(<) : [ on $(<) return $(PCH_FILE) ] ;
 }
 
-actions compile.c++.without-pch {
-  "$(CONFIG_COMMAND)" -c -x c++ $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -o "$(<)" "$(>)"
-}
-
-actions compile.c++.with-pch bind PCH_FILE
+actions compile.c++ bind PCH_FILE
 {
-  "$(CONFIG_COMMAND)" -c -x c++ $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -include-pch -Xclang "$(PCH_FILE)" -include"$(FORCE_INCLUDES)" -o "$(<)" "$(>)"
+  "$(CONFIG_COMMAND)" -c -x c++ $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang$(_)-include-pch$(_)-Xclang$(_)"$(PCH_FILE)" -include"$(FORCE_INCLUDES)" -o "$(<)" "$(>)"
 }
 
 rule compile.c ( targets * : sources * : properties * )
 {
-  local pch-file = [ on $(<) return $(PCH_FILE) ] ;
-
-  if $(pch-file) {
-    DEPENDS $(<) : $(pch-file) ;
-    clang-linux.compile.c.with-pch $(targets) : $(sources) ;
-  }
-  else {
-    clang-linux.compile.c.without-pch $(targets) : $(sources) ;
-  }
+  DEPENDS $(<) : [ on $(<) return $(PCH_FILE) ] ;
 }
 
-actions compile.c.without-pch
+actions compile.c bind PCH_FILE
 {
-  "$(CONFIG_COMMAND)" -c -x c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -c -o "$(<)" "$(>)"
-}
-
-actions compile.c.with-pch bind PCH_FILE
-{
-  "$(CONFIG_COMMAND)" -c -x c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang -include-pch -Xclang "$(PCH_FILE)" -include"$(FORCE_INCLUDES)" -c -o "$(<)" "$(>)"
+  "$(CONFIG_COMMAND)" -c -x c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -Xclang$(_)-include-pch$(_)-Xclang$(_)"$(PCH_FILE)" -include"$(FORCE_INCLUDES)" -c -o "$(<)" "$(>)"
 }
 
 ###############################################################################
@@ -214,7 +189,8 @@ RM = [ common.rm-command ] ;
 rule compile.c++.pch ( targets * : sources * : properties * ) {
 }
 
-actions compile.c++.pch {
+actions compile.c++.pch
+{
   $(RM) -f "$(<)" && "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -Xclang -emit-pch -o "$(<)" "$(>)"
 }
 

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -597,17 +597,9 @@ generators.override gcc.compile.c++.pch : pch.default-cpp-pch-generator ;
 
 toolset.flags gcc.compile PCH_FILE <pch>on : <pch-file> ;
 
-rule compile.c++.pch ( targets * : sources * : properties * )
-{
-}
-
 actions compile.c++.pch
 {
     "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
-}
-
-rule compile.c.pch ( targets * : sources * : properties * )
-{
 }
 
 actions compile.c.pch

--- a/src/tools/intel-linux.jam
+++ b/src/tools/intel-linux.jam
@@ -260,9 +260,6 @@ actions compile.c bind PCH_FILE
     LD_LIBRARY_PATH="$(RUN_PATH)" "$(CONFIG_COMMAND)" -c -xc $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -use-pch"$(PCH_FILE)" -c -o "$(<)" "$(>)"
 }
 
-rule compile.c++.pch ( targets * : sources * : properties * )
-{
-}
 #
 # Compiling a pch first deletes any existing *.pchi file, as Intel's compiler
 # won't over-write an existing pch: instead it creates filename$1.pchi, filename$2.pchi
@@ -276,10 +273,6 @@ actions compile.c++.pch
 actions compile.fortran
 {
     LD_LIBRARY_PATH="$(RUN_PATH)" "ifort" -c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
-}
-
-rule compile.c.pch ( targets * : sources * : properties * )
-{
 }
 
 actions compile.c.pch


### PR DESCRIPTION
* Removed empty rules
* Removed PCH suffix override (missed in https://github.com/boostorg/build/pull/368)
* Removed PCH file explicit removal before creation (should be tested in pch.py test)
* Unified `<pch>on` and `<pch>off` compilation actions