### PR TITLE
Cleanup darwin toolsets static linking

### DIFF
--- a/src/tools/clang-darwin.jam
+++ b/src/tools/clang-darwin.jam
@@ -155,47 +155,6 @@ actions compile.mm
     "$(CONFIG_COMMAND)" -x objective-c++ $(OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
 }
 
-# Default value. Mostly for the sake of clang-linux
-# that inherits from gcc, but does not has the same
-# logic to set the .AR variable. We can put the same
-# logic in clang-linux, but that's hardly worth the trouble
-# as on Linux, 'ar' is always available.
-.AR = ar ;
-
-rule archive ( targets * : sources * : properties * )
-{
-  # Always remove archive and start again. Here's rationale from
-  # Andre Hentz:
-  #
-  # I had a file, say a1.c, that was included into liba.a.
-  # I moved a1.c to a2.c, updated my Jamfiles and rebuilt.
-  # My program was crashing with absurd errors.
-  # After some debugging I traced it back to the fact that a1.o was *still*
-  # in liba.a
-  #
-  # Rene Rivera:
-  #
-  # Originally removing the archive was done by splicing an RM
-  # onto the archive action. That makes archives fail to build on NT
-  # when they have many files because it will no longer execute the
-  # action directly and blow the line length limit. Instead we
-  # remove the file in a different action, just before the building
-  # of the archive.
-  #
-  local clean.a = $(targets[1])(clean) ;
-  TEMPORARY $(clean.a) ;
-  NOCARE $(clean.a) ;
-  LOCATE on $(clean.a) = [ on $(targets[1]) return $(LOCATE) ] ;
-  DEPENDS $(clean.a) : $(sources) ;
-  DEPENDS $(targets) : $(clean.a) ;
-  common.RmTemps $(clean.a) : $(targets) ;
-}
-
-actions piecemeal archive
-{
-  "$(.AR)" $(AROPTIONS) rsc "$(<)" "$(>)"
-}
-
 # Declare actions for linking
 rule link ( targets * : sources * : properties * )
 {

--- a/src/tools/intel-darwin.jam
+++ b/src/tools/intel-darwin.jam
@@ -171,51 +171,6 @@ actions compile.c++
     "$(CONFIG_COMMAND)" -xc++ $(OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
 }
 
-flags intel-darwin ARFLAGS <archiveflags> ;
-
-# Default value. Mostly for the sake of intel-linux
-# that inherits from gcc, but does not has the same
-# logic to set the .AR variable. We can put the same
-# logic in intel-linux, but that's hardly worth the trouble
-# as on Linux, 'ar' is always available.
-.AR = ar ;
-
-rule archive ( targets * : sources * : properties * )
-{
-  # Always remove archive and start again. Here's rationale from
-  # Andre Hentz:
-  #
-  # I had a file, say a1.c, that was included into liba.a.
-  # I moved a1.c to a2.c, updated my Jamfiles and rebuilt.
-  # My program was crashing with absurd errors.
-  # After some debugging I traced it back to the fact that a1.o was *still*
-  # in liba.a
-  #
-  # Rene Rivera:
-  #
-  # Originally removing the archive was done by splicing an RM
-  # onto the archive action. That makes archives fail to build on NT
-  # when they have many files because it will no longer execute the
-  # action directly and blow the line length limit. Instead we
-  # remove the file in a different action, just before the building
-  # of the archive.
-  #
-  local clean.a = $(targets[1])(clean) ;
-  TEMPORARY $(clean.a) ;
-  NOCARE $(clean.a) ;
-  LOCATE on $(clean.a) = [ on $(targets[1]) return $(LOCATE) ] ;
-  DEPENDS $(clean.a) : $(sources) ;
-  DEPENDS $(targets) : $(clean.a) ;
-  common.RmTemps $(clean.a) : $(targets) ;
-}
-
-actions piecemeal archive
-{
-  "$(.AR)" $(AROPTIONS) rsc "$(<)" "$(>)"
-}
-
-flags intel-darwin.link USER_OPTIONS <linkflags> ;
-
 # Declare actions for linking
 rule link ( targets * : sources * : properties * )
 {


### PR DESCRIPTION
After removing `ranlib` call there is no more darwin-specific logic, it duplicates base/parent logic and could be removed.
