### PR TITLE
Move Objective-C support to GCC toolset

### DIFF
--- a/src/tools/clang-darwin.jam
+++ b/src/tools/clang-darwin.jam
@@ -31,9 +31,6 @@ generators.override clang-darwin.searched-lib-generator : searched-lib-generator
 generators.override clang-darwin.compile.c.pch   : pch.default-c-pch-generator   ;
 generators.override clang-darwin.compile.c++.pch : pch.default-cpp-pch-generator ;
 
-generators.register-c-compiler clang-darwin.compile.m : OBJECTIVE_C : OBJ : <toolset>clang <toolset-clang:platform>darwin ;
-generators.register-c-compiler clang-darwin.compile.mm : OBJECTIVE_CPP : OBJ : <toolset>clang <toolset-clang:platform>darwin ;
-
 toolset.inherit-rules clang-darwin : gcc ;
 toolset.inherit-flags clang-darwin : gcc
         : <inlining>full
@@ -86,18 +83,10 @@ rule get-short-version ( command-string )
 
 SPACE = " " ;
 
-toolset.flags clang-darwin.compile.m OPTIONS <mflags> ;
-toolset.flags clang-darwin.compile.mm OPTIONS <mflags> ;
-toolset.flags clang-darwin.compile.mm OPTIONS <mmflags> ;
-
 # Declare flags and action for compilation.
 
 # For clang, 'on' and 'full' are identical
 toolset.flags clang-darwin.compile OPTIONS <inlining>full : -Wno-inline ;
-
-# SJW 12/2017: Support for <flags> is widely inconsistent.
-# shouldn't this be handled by the common gcc?
-toolset.flags clang-darwin.compile OPTIONS <flags> ;
 
 # LTO
 toolset.flags clang-darwin.compile OPTIONS <lto>on/<lto-mode>thin : -flto=thin ;
@@ -143,16 +132,6 @@ actions compile.c.pch
 actions compile.c++.pch
 {
     "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -o "$(<)" "$(>)"
-}
-
-actions compile.m
-{
-    "$(CONFIG_COMMAND)" -x objective-c $(OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
-}
-
-actions compile.mm
-{
-    "$(CONFIG_COMMAND)" -x objective-c++ $(OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
 }
 
 # Declare actions for linking

--- a/src/tools/clang-vxworks.jam
+++ b/src/tools/clang-vxworks.jam
@@ -80,8 +80,6 @@ toolset.flags clang-vxworks.compile INCLUDES <include> ;
 # For clang, 'on' and 'full' are identical
 toolset.flags clang-vxworks.compile OPTIONS <inlining>full : -Wno-inline ;
 
-toolset.flags clang-vxworks.compile OPTIONS <flags> ;
-
 
 actions compile.c
 {

--- a/src/tools/darwin.jam
+++ b/src/tools/darwin.jam
@@ -408,15 +408,6 @@ local rule init-available-sdk-versions ( condition * : root ? )
     return $(result) ;
 }
 
-# Generic options.
-flags darwin.compile OPTIONS <flags> ;
-
-# The following adds objective-c support to darwin.
-# Thanks to http://thread.gmane.org/gmane.comp.lib.boost.build/13759
-
-generators.register-c-compiler darwin.compile.m : OBJECTIVE_C : OBJ : <toolset>darwin ;
-generators.register-c-compiler darwin.compile.mm : OBJECTIVE_CPP : OBJ : <toolset>darwin ;
-
 rule setup-address-model ( targets * : sources * : properties * )
 {
     local ps = [ property-set.create $(properties) ] ;

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -36,6 +36,10 @@ not specified, the `g++` binary will be searched in PATH.
 The following options can be provided, using
 _`<option-name>option-value syntax`_:
 
+`asmflags`::
+Specifies additional compiler flags that will be used when compiling assembler
+sources.
+
 `cflags`::
 Specifies additional compiler flags that will be used when compiling C
 sources.
@@ -44,9 +48,21 @@ sources.
 Specifies additional compiler flags that will be used when compiling C++
 sources.
 
+`fflags`::
+Specifies additional compiler flags that will be used when compiling Fortran
+sources.
+
+`mflags`::
+Specifies additional compiler flags that will be used when compiling
+Objective-C sources.
+
+`mmflags`::
+Specifies additional compiler flags that will be used when compiling
+Objective-C++ sources.
+
 `compileflags`::
-Specifies additional compiler flags that will be used when compiling both C
-and C++ sources.
+Specifies additional compiler flags that will be used when compiling any
+language sources.
 
 `linkflags`::
 Specifies additional command line options that will be passed to the linker.
@@ -434,6 +450,8 @@ generators.register-c-compiler gcc.compile.c.preprocess   : C   : PREPROCESSED_C
 generators.register-c-compiler gcc.compile.c++ : CPP : OBJ : <toolset>gcc ;
 generators.register-c-compiler gcc.compile.c   : C   : OBJ : <toolset>gcc ;
 generators.register-c-compiler gcc.compile.asm : ASM : OBJ : <toolset>gcc ;
+generators.register-c-compiler gcc.compile.m   : OBJECTIVE_C   : OBJ : <toolset>gcc ;
+generators.register-c-compiler gcc.compile.mm  : OBJECTIVE_CPP : OBJ : <toolset>gcc ;
 
 generators.register [ new fortran-compiling-generator
     gcc.compile.fortran : FORTRAN FORTRAN90 : OBJ : <toolset>gcc ] ;
@@ -521,6 +539,16 @@ rule compile.asm ( targets * : sources * : properties * )
 actions compile.asm
 {
     "$(CONFIG_COMMAND)" $(LANG) $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
+}
+
+actions compile.m
+{
+    "$(CONFIG_COMMAND)" -x objective-c $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
+}
+
+actions compile.mm
+{
+    "$(CONFIG_COMMAND)" -x objective-c++ $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
 }
 
 ###
@@ -659,6 +687,8 @@ toolset.flags gcc.compile INCLUDES <include> ;
 toolset.flags gcc.compile FORCE_INCLUDES <force-include> ;
 toolset.flags gcc.compile.c++ TEMPLATE_DEPTH <c++-template-depth> ;
 toolset.flags gcc.compile.fortran USER_OPTIONS <fflags> ;
+toolset.flags gcc.compile.m USER_OPTIONS <mflags> ;
+toolset.flags gcc.compile.mm USER_OPTIONS <mmflags> ;
 
 ###
 ### Linking generators and actions.

--- a/test/lang_objc.py
+++ b/test/lang_objc.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+# Copyright Nikita Kniazev 2021.
+# Distributed under the Boost Software License, Version 1.0. (See
+# accompanying file LICENSE.txt or copy at
+# https://www.bfgroup.xyz/b2/LICENSE.txt)
+
+import BoostBuild
+
+t = BoostBuild.Tester()
+
+t.write("jamroot.jam", """
+obj a : hello.m ;
+obj b : hello.mm ;
+""")
+
+t.write("hello.m", '''\
+@interface Foo
+@end
+''')
+t.write("hello.mm", '''\
+@interface Foo
+@end
+
+class Bar {};
+''')
+
+t.run_build_system()
+t.expect_addition("bin/$toolset/debug*/a.obj")
+t.expect_addition("bin/$toolset/debug*/b.obj")
+t.expect_nothing_more()
+
+t.cleanup()

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -344,6 +344,10 @@ if toolset.startswith("clang") or toolset.startswith("gcc") or toolset.startswit
     if sys.platform != "darwin": # clang-darwin does not yet support
         tests.append("feature_force_include")
 
+# Clang includes Objective-C driver everywhere, but GCC usually in a separate gobj package
+if toolset.startswith("clang") or "darwin" in toolset:
+    tests.append("lang_objc")
+
 # Disable on OSX as it doesn't seem to work for unknown reasons.
 if sys.platform != 'darwin':
     tests.append("builtin_glob_archive")


### PR DESCRIPTION
Removes code duplication in darwin and clang-darwin toolsets.

Removes undocumented `<flags>` from several toolsets, there is documented `<compileflags>` that should be used instead.