### PR TITLE
Remove architecture=combined/combined-x86-power

### DIFF
--- a/src/tools/darwin.jam
+++ b/src/tools/darwin.jam
@@ -408,110 +408,10 @@ local rule init-available-sdk-versions ( condition * : root ? )
     return $(result) ;
 }
 
-rule setup-address-model ( targets * : sources * : properties * )
-{
-    local ps = [ property-set.create $(properties) ] ;
-    local arch = [ $(ps).get <architecture> ] ;
-    local instruction-set = [ $(ps).get <instruction-set> ] ;
-    local address-model = [ $(ps).get <address-model> ] ;
-    local osx-version = [ $(ps).get <macosx-version> ] ;
-    local gcc-version = [ $(ps).get <toolset-darwin:version> ] ;
-    gcc-version = $(.real-version.$(gcc-version)) ;
-    local options ;
-
-    local support-ppc64 = 1 ;
-
-    osx-version ?= $(.host-osx-version) ;
-
-    switch $(osx-version)
-    {
-        case iphone* :
-        {
-            support-ppc64 = ;
-        }
-
-        case * :
-        if $(osx-version) && ! [ version.version-less [ regex.split $(osx-version) \\. ] : 10 6 ]
-        {
-            # When targeting 10.6:
-            # - gcc 4.2 will give a compiler errir if ppc64 compilation is requested
-            # - gcc 4.0 will compile fine, somehow, but then fail at link time
-            support-ppc64 = ;
-        }
-    }
-    switch $(arch)
-    {
-        case combined :
-        {
-            if $(address-model) = 32_64 {
-                if $(support-ppc64) {
-                    options = -arch i386 -arch ppc -arch x86_64 -arch ppc64 ;
-                } else {
-                    # Build 3-way binary
-                    options = -arch i386 -arch ppc -arch x86_64 ;
-                }
-            } else if $(address-model) = 64 {
-                if $(support-ppc64) {
-                    options = -arch x86_64 -arch ppc64 ;
-                } else {
-                    errors.user-error "64-bit PPC compilation is not supported when targeting OSX 10.6 or later" ;
-                }
-            } else {
-                options = -arch i386 -arch ppc ;
-            }
-        }
-
-        case x86 :
-        {
-            if $(address-model) = 32_64 {
-                options = -arch i386 -arch x86_64 ;
-            } else if $(address-model) = 64 {
-                options = -arch x86_64 ;
-            } else {
-                options = -arch i386 ;
-            }
-        }
-
-        case power :
-        {
-            if ! $(support-ppc64)
-              && (  $(address-model) = 32_64 || $(address-model) = 64 )
-            {
-                errors.user-error "64-bit PPC compilation is not supported when targeting OSX 10.6 or later" ;
-            }
-
-            if $(address-model) = 32_64 {
-                options = -arch ppc -arch ppc64 ;
-            } else if $(address-model) = 64 {
-                options = -arch ppc64 ;
-            } else {
-                options = -arch ppc ;
-            }
-        }
-
-        case arm :
-        {
-            if $(instruction-set) {
-                options = -arch$(_)$(instruction-set) ;
-            } else if $(address-model) = 64 {
-                options = -arch arm64 ;
-            } else {
-                options = -arch arm ;
-            }
-        }
-    }
-
-    if $(options)
-    {
-        OPTIONS on $(targets) += $(options) ;
-    }
-}
-
 rule compile.m ( targets * : sources * : properties * )
 {
     LANG on $(<) = "-x objective-c" ;
     gcc.set-fpic-options $(targets) : $(sources) : $(properties) ;
-    setup-address-model $(targets) : $(sources) : $(properties) ;
 }
 
 actions compile.m
@@ -523,7 +423,6 @@ rule compile.mm  ( targets * : sources * : properties * )
 {
     LANG on $(<) = "-x objective-c++" ;
     gcc.set-fpic-options $(targets) : $(sources) : $(properties) ;
-    setup-address-model $(targets) : $(sources) : $(properties) ;
 }
 
 actions compile.mm
@@ -581,7 +480,6 @@ local rule prepare-framework-path ( target + )
 rule link ( targets * : sources * : properties * )
 {
     DEPENDS $(targets) : [ on $(targets) return $(FORCE_LOAD) ] ;
-    setup-address-model $(targets) : $(sources) : $(properties) ;
     prepare-framework-path $(<) ;
 }
 
@@ -597,7 +495,6 @@ actions link bind LIBRARIES FORCE_LOAD
 
 rule link.dll ( targets * : sources * : properties * )
 {
-    setup-address-model $(targets) : $(sources) : $(properties) ;
     prepare-framework-path $(<) ;
 }
 

--- a/src/tools/features/architecture-feature.jam
+++ b/src/tools/features/architecture-feature.jam
@@ -10,7 +10,7 @@ import feature ;
 [[bbv2.builtin.features.architecture]]`architecture`::
 *Allowed values:* `x86`, `ia64`, `sparc`, `power`, `mips`, `mips1`, `mips2`,
 `mips3`, `mips4`, `mips32`, `mips32r2`, `mips64`, `parisc`, `arm`,
-`s390x`, `combined`, `combined-x86-power`.
+`s390x`.
 +
 Specifies the general processor family to generate code for.
 
@@ -44,12 +44,6 @@ feature.feature architecture
 
         # z Systems (aka s390x)
         s390x
-
-        # Combined architectures for platforms/toolsets that support building for
-        # multiple architectures at once. "combined" would be the default multi-arch
-        # for the toolset.
-        combined
-        combined-x86-power
     :
         propagated optional
     ;


### PR DESCRIPTION
## Proposed changes

`combined-x86-power` seems to be completely unused and `combined` is used only in darwin toolset for Objective-C compilation which seems to be broken for 4 years because it uses gcc.set-fpic-options which was removed in 12decb3ce680031b915f69902795eec47224fc7d.

Boost has three libraries that mentions architecture=combined, I have checked they will not brake after this change.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [ ] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [ ] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
