### PR TITLE
The engine can now be built with MinGW-w64 configured with --threads=win32.

### DIFF
--- a/src/engine/check_cxx11.cpp
+++ b/src/engine/check_cxx11.cpp
@@ -10,12 +10,20 @@ available. This is used by the build script to guess and check the
 compiler to build the engine with.
 */
 
-// Some headers we depend on..
+// Some headers we test...
 #include <thread>
+#include <memory>
 
 
 int main()
 {
     // Check for basic thread calls.
+    // [2020-08-19]
+    //   Mingw-w64 with win32 threading model (as opposed to posix threading model) does not really have std::thread etc.
+    //   Please see comments in sysinfo.cpp.
+    #ifndef _WIN32
     { auto _ = std::thread::hardware_concurrency(); }
+    #endif
+
+    const std::unique_ptr <float> pf {new float {3.14159f}};
 }


### PR DESCRIPTION
This is the case for `i686-w64-mingw32-g++` and `x86_64-w64-mingw32-g++`
distributed with the last versions of Cygwin compatible with Windows XP
(www.crouchingtigerhiddenfruitbat.org/Cygwin/timemachine.html).

The MinGW-w64 toolchains are very powerful, just like their gcc counterparts.
Even the ones with win32 threading model (as opposed to posix threading model),
while not able to use `std::thread`, can still build-and-use Boost.Thread.
(which, arguably, is more powerful than the Standard counterpart
for example with its support for thread interruption
-- which is less intrusive than the one offered by C++20 `std::jthread`).

For Windows XP, MinGW-w64 toolchains might be the only ones to support C++11.
Visual C++ has only been supporting C++11 since 2013
(and those versions require-and-often-target newer versions of Windows).

The only part of `<thread>` we were using was `std::thread::hardware_concurrency`
(in order to obtain the default value for `b2`'s `-j` option).
For Windows, we now use `dwNumberOfProcessors` (in `SYSTEM_INFO`) and `GetSystemInfo`.



Testing information:

Using `b2` built with `i686-w64-mingw32-g++` from Cygwin, one can build (in `-std=c++11` etc. modes) Boost.Thread and a project depending on Boost.Thread.