### PR TITLE
Unify Clang and GCC PCH creation

### DIFF
--- a/src/tools/clang-darwin.jam
+++ b/src/tools/clang-darwin.jam
@@ -124,16 +124,6 @@ actions compile.c++ bind PCH_FILE
     "$(CONFIG_COMMAND)" -x c++ $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" $(.include-pch)"$(PCH_FILE)" -c -o "$(<)" "$(>)"
 }
 
-actions compile.c.pch
-{
-    "$(CONFIG_COMMAND)" -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -o "$(<)" "$(>)"
-}
-
-actions compile.c++.pch
-{
-    "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -o "$(<)" "$(>)"
-}
-
 # Declare actions for linking
 rule link ( targets * : sources * : properties * )
 {

--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -171,19 +171,6 @@ actions compile.c bind PCH_FILE
 }
 
 ###############################################################################
-# PCH emission
-
-actions compile.c++.pch
-{
-  "$(CONFIG_COMMAND)" -c -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -Xclang -emit-pch -o "$(<)" "$(>)"
-}
-
-actions compile.c.pch
-{
-  "$(CONFIG_COMMAND)" -c -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -Xclang -emit-pch -o "$(<)" "$(>)"
-}
-
-###############################################################################
 # Linking
 
 local soname-os = [ set.difference $(all-os) : windows ] ;

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -608,12 +608,12 @@ toolset.flags gcc.compile PCH_FILE <pch>on : <pch-file> ;
 
 actions compile.c++.pch
 {
-    "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
+    "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -c -o "$(<)" "$(>)"
 }
 
 actions compile.c.pch
 {
-    "$(CONFIG_COMMAND)" -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -c -o "$(<)" "$(>)"
+    "$(CONFIG_COMMAND)" -x c-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -c -o "$(<)" "$(>)"
 }
 
 ###


### PR DESCRIPTION
Clang has GCC-compatible PCH generation interface, no need to override and re-implement PCH generation in Clang at all.
