### PR TITLE
Issue/64

### DIFF
--- a/src/tools/qt5.jam
+++ b/src/tools/qt5.jam
@@ -306,7 +306,6 @@ rule init ( prefix : version ? : condition * : namespace ? : infix ? : full_bin 
        local usage-requirements =
            <include>$(.incprefix)
            <library-path>$(.libprefix)
-           <threading>multi
            <allow>qt5 ;
 
        if $(link) in shared

--- a/test/qt5.py
+++ b/test/qt5.py
@@ -10,10 +10,11 @@ import os
 
 # Run test in real directory in order to find Boost.Test via Boost Top-Level
 # Jamroot.
-qt5_dir = os.getcwd() + "/qt5"
+qt5_dir = os.path.dirname(os.path.abspath(__file__)) + "/qt5"
 
 t = BoostBuild.Tester(workdir=qt5_dir)
 
 t.run_build_system()
-
+# Fails if a warning is thrown
+t.fail_test( t.stdout().find("warning") != -1 )
 t.cleanup()

--- a/test/qt5/initialization.cpp
+++ b/test/qt5/initialization.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main()
+{
+    // dummy file to test initialization of qt
+    return 0;
+}

--- a/test/qt5/jamroot.jam
+++ b/test/qt5/jamroot.jam
@@ -9,6 +9,20 @@ import cast ;
 
 path-constant CWD : . ;
 
+if ! [ qt5.initialized ]
+{
+    # assuming qt5 from system
+    using qt5 : /usr/ ;
+
+    project qttest-initialization : ;
+
+    alias qt-tests-initialization :
+      [ run initialization.cpp /qt5//QtCore ]
+    : # requirements
+    : # default-build
+    : # usage-requirements
+    ; 
+}
 
 if [ qt5.initialized ]
 {

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -284,6 +284,8 @@ tests = ["abs_workdir",
          "project_test3",
          "project_test4",
          "property_expansion",
+# FIXME: Disabled due lack of qt5 detection
+#         "qt5",
          "rebuilds",
          "relative_sources",
          "remove_requirement",


### PR DESCRIPTION
## Proposed changes
Removing <threading>multi from qt5.jam as it generating a warning.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ x] Other (please describe): Test

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [ x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [ x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ x] I checked that tests pass locally with my changes
- [ x] I added tests that prove my fix is effective or that my feature works
- [ x] I added necessary documentation (if appropriate)

## Further comments
Qt5.jam is not being actively tested. I left the test commented at least to make others aware there is a test for this. My test detected if warnings were thrown by qt5 testing.

We need a way to pass a qt5 installation to enable this test permanently.
