### PR TITLE
The engine can now be built with MinGW-w64 configured with --threads=win32.

### DIFF
--- a/src/engine/check_cxx11.cpp
+++ b/src/engine/check_cxx11.cpp
@@ -10,12 +10,21 @@ available. This is used by the build script to guess and check the
 compiler to build the engine with.
 */
 
-// Some headers we depend on..
+// Some headers we test...
 #include <thread>
+#include <memory>
 
 
 int main()
 {
     // Check for basic thread calls.
+    // [2020-08-19]
+    //   Mingw-w64 with win32 threading model (as opposed to posix threading model) does not really have std::thread etc.
+    //   Please see comments in sysinfo.cpp.
+    #ifndef _WIN32
     { auto _ = std::thread::hardware_concurrency(); }
+    #endif
+
+    // [2021-08-07] We check the following C++11 features: brace initialization, unique_ptr. Plus the author's ability to memorize some digits.
+    { const std::unique_ptr <float> pf {new float {3.14159f}}; }
 }

--- a/src/engine/sysinfo.cpp
+++ b/src/engine/sysinfo.cpp
@@ -16,6 +16,8 @@
 
 #if !defined(OS_NT)
 #include <unistd.h>
+#else
+#include <windows.h>
 #endif
 
 #if defined(OS_LINUX) || defined(__GLIBC__)
@@ -90,7 +92,33 @@ namespace
 
     unsigned int std_thread_hardware_concurrency()
     {
-        return std::thread::hardware_concurrency();
+        // [2020-08-19]
+        //   Mingw-w64 (e.g. i686-w64-mingw-32-g++ from Cygwin, g++-mingw-w64-i686-win32) does not have std::thread etc.
+        //   But we should still allow building the engine with this (important) toolset:
+        //     - It is free, lightweight, standards-conforming.
+        //     - It might be the only C++11 toolset for Windows XP.
+        //         (Please see http://www.crouchingtigerhiddenfruitbat.org/Cygwin/timemachine.html !)
+        //     - It is powerful enough even without std::thread etc. For example, it can build-and-use Boost.Thread.
+        //     - The only thing currently used from std::thread is this call to hardware_concurrency !
+        #if ! defined (_WIN32)
+            return std::thread::hardware_concurrency();
+        #else
+            return 0;
+        #endif
+    }
+
+    unsigned int win32_logicalcpu()
+    {
+        #if defined (_WIN32)
+            SYSTEM_INFO si;
+            {
+                GetSystemInfo (&si);
+            }
+
+            return si.dwNumberOfProcessors;
+        #else
+            return 0;
+        #endif
     }
 }
 
@@ -128,6 +156,10 @@ unsigned int b2::system_info::cpu_thread_count()
     if (cpu_thread_count_ == 0)
     {
         cpu_thread_count_ = std_thread_hardware_concurrency();
+    }
+    if (cpu_thread_count_ == 0)
+    {
+        cpu_thread_count_ = win32_logicalcpu();
     }
     if (cpu_thread_count_ == 0)
     {


### PR DESCRIPTION
This is the case for i686-w64-mingw32-g++ and x86_64-w64-mingw32-g++
distributed with the last versions of Cygwin compatible with Windows XP
(www.crouchingtigerhiddenfruitbat.org/Cygwin/timemachine.html).

The MinGW-w64 toolchains are very powerful, just like their gcc counterparts.
Even the ones with win32 threading model (as opposed to posix threading model),
while not able to use std::thread, can still build-and-use Boost.Thread.
(which, arguably, is more powerful than the Standard counterpart
for example with its support for thread interruption
-- which is less intrusive than the one offered by C++20 std::jthread).

For Windows XP, MinGW-w64 toolchains might be the only ones to support C++11.
Visual C++ has only been supporting C++11 since 2013
(and those versions require-and-often-target newer versions of Windows).

The only part of <thread> we were using was std::thread::hardware_concurrency
(in order to obtain the default value for b2's -j option).
For Windows, we now use dwNumberOfProcessors (in SYSTEM_INFO) and GetSystemInfo.