### PR TITLE
Add arm/arm64 target support in clang-win config

### DIFF
--- a/src/tools/clang-win.jam
+++ b/src/tools/clang-win.jam
@@ -93,102 +93,149 @@ rule init ( version ? : command * : options * )
 
     for local addr in 32 64
     {
-        local config = [ SPLIT_BY_CHARACTERS [ SHELL "$(compiler) -m$(addr) -### foo.obj /link 2>&1" ] : "\n" ] ;
-
-        local match = 1 ;
-        local items ;
-
-        while $(match)
+        for local arch in x86 arm
         {
-            match = [ MATCH "^ *(\"[^\"]*\")(.*)" : $(config) ] ;
-
-            if $(match)
+            local clang-arch ;
+            if $(arch) = x86
             {
-                items += $(match[1]) ;
-                config = $(match[2]) ;
+                if $(addr) = 32 { clang-arch = i386 ; } else { clang-arch = x86_64 ; }
             }
-        }
-
-        local ml ;
-
-        if $(items)
-        {
-            ml = [ regex.replace $(items[1]) "x64\\\\+link\\.exe" "x64\\ml64.exe" ] ;
-            ml = [ regex.replace $(ml) "x86\\\\+link\\.exe" "x86\\ml.exe" ] ;
-
-            if ! [ MATCH "(ml\\.exe)" "(ml64\\.exe)" : $(ml) ]
+            else if $(arch) = arm
             {
-                ml = ;
+                if $(addr) = 32 { clang-arch = arm ; } else { clang-arch = aarch64 ; }
             }
-        }
 
-        local assembler = [ get-option "assembler" : $(addr) : $(options) ] ;
-        assembler ?= $(ml) ;
-        if $(addr) = 32 { assembler ?= ml.exe ; } else { assembler ?= ml64.exe ; }
+            local config = [ SPLIT_BY_CHARACTERS [ SHELL "$(compiler) --target=$(clang-arch)-pc-windows-msvc -### foo.obj /link 2>&1" ] : "\n" ] ;
 
-        local link ;
+            local match = 1 ;
+            local items ;
 
-        if $(items)
-        {
-            link = [ regex.replace $(items[1]) "\\\\+HostX64\\\\+x86\\\\+" "\\HostX86\\x86\\" ] ;
-        }
-
-        local archiver = [ get-option "archiver" : $(addr) : $(options) ] ;
-
-        if $(link)
-        {
-            archiver ?= "$(link) /lib" ;
-        }
-        archiver ?= lib.exe ;
-
-        .notice "$(addr):" "using assembler '$(assembler)'" ;
-        .notice "$(addr):" "using archiver '$(archiver)'" ;
-
-        local manifest-tool = [ get-option "manifest-tool" : $(addr) : $(options) ] ;
-        local resource-compiler = [ get-option "resource-compiler" : $(addr) : $(options) ] ;
-        local mc-compiler = [ get-option "mc-compiler" : $(addr) : $(options) ] ;
-        local idl-compiler = [ get-option "idl-compiler" : $(addr) : $(options) ] ;
-
-        for local item in $(items)
-        {
-            match = [ MATCH "\"-libpath:(.*)\\\\+Lib\\\\.*\\\\um\\\\+x(.*)\"" : $(item) ] ;
-
-            if $(match)
+            while $(match)
             {
-                local sdk-path = "$(match[1])\\bin\\x$(match[2])" ;
-                .notice "$(addr):" "using SDK path '$(sdk-path)'" ;
+                match = [ MATCH "^ *(\"[^\"]*\")(.*)" : $(config) ] ;
 
-                manifest-tool ?= "\"$(sdk-path)\\mt.exe\"" ;
-                resource-compiler ?= "\"$(sdk-path)\\rc.exe\"" ;
-                mc-compiler ?= "\"$(sdk-path)\\mc.exe\"" ;
-                idl-compiler ?= "\"$(sdk-path)\\midl.exe\"" ;
+                if $(match)
+                {
+                    items += $(match[1]) ;
+                    config = $(match[2]) ;
+                }
             }
+
+            local asm ;
+
+            if $(items)
+            {
+                asm = [ regex.replace $(items[1]) "x64\\\\+link\\.exe" "x64\\ml64.exe" ] ;
+                asm = [ regex.replace $(asm) "x86\\\\+link\\.exe" "x86\\ml.exe" ] ;
+                asm = [ regex.replace $(asm) "arm64\\\\+link\\.exe" "arm64\\armasm64.exe" ] ;
+                asm = [ regex.replace $(asm) "arm\\\\+link\\.exe" "arm\\armasm.exe" ] ;
+
+                if ! [ MATCH "(ml\\.exe)" "(ml64\\.exe)" "(armasm64\\.exe)" "(armasm\\.exe)" : $(asm) ]
+                {
+                    asm = ;
+                }
+            }
+
+            local assembler = [ get-option "assembler" : $(addr) : $(options) ] ;
+            assembler ?= $(asm) ;
+            if $(arch) = x86
+            {
+                if $(addr) = 32 { assembler ?= ml.exe ; } else { assembler ?= ml64.exe ; }
+            }
+            else if $(arch) = arm
+            {
+                if $(addr) = 32 { assembler ?= armasm.exe ; } else { assembler ?= armasm64.exe ; }
+            }
+
+            local linker ;
+
+            if $(items)
+            {
+                linker = [ regex.replace $(items[1]) "\\\\+HostX64\\\\+x86\\\\+" "\\HostX86\\x86\\" ] ;
+            }
+
+            .notice "$(arch)-$(addr):" "using linker '$(linker)'" ;
+
+            local archiver = [ get-option "archiver" : $(addr) : $(options) ] ;
+
+            if $(linker)
+            {
+                archiver ?= "$(linker) /lib" ;
+            }
+            archiver ?= lib.exe ;
+
+            .notice "$(arch)-$(addr):" "using assembler '$(assembler)'" ;
+            .notice "$(arch)-$(addr):" "using archiver '$(archiver)'" ;
+
+            local manifest-tool = [ get-option "manifest-tool" : $(addr) : $(options) ] ;
+            local resource-compiler = [ get-option "resource-compiler" : $(addr) : $(options) ] ;
+            local mc-compiler = [ get-option "mc-compiler" : $(addr) : $(options) ] ;
+            local idl-compiler = [ get-option "idl-compiler" : $(addr) : $(options) ] ;
+
+            for local item in $(items)
+            {
+                match = [ MATCH "\"-libpath:(.*)\\\\+Lib\\\\.*\\\\um\\\\+x(.*)\"" : $(item) ] ;
+
+                if $(match)
+                {
+                    local sdk-path = "$(match[1])\\bin\\x$(match[2])" ;
+                    .notice "$(arch)-$(addr):" "using SDK path '$(sdk-path)'" ;
+
+                    manifest-tool ?= "\"$(sdk-path)\\mt.exe\"" ;
+                    resource-compiler ?= "\"$(sdk-path)\\rc.exe\"" ;
+                    mc-compiler ?= "\"$(sdk-path)\\mc.exe\"" ;
+                    idl-compiler ?= "\"$(sdk-path)\\midl.exe\"" ;
+                }
+            }
+
+            manifest-tool ?= mt.exe ;
+            resource-compiler ?= rc.exe ;
+            mc-compiler ?= mc.exe ;
+            idl-compiler ?= midl.exe ;
+
+            .notice "$(arch)-$(addr):" "using manifest-tool '$(manifest-tool)'" ;
+            .notice "$(arch)-$(addr):" "using resource-compiler '$(resource-compiler)'" ;
+            .notice "$(arch)-$(addr):" "using mc-compiler '$(mc-compiler)'" ;
+            .notice "$(arch)-$(addr):" "using idl-compiler '$(idl-compiler)'" ;
+
+            local linker-arch ;
+            if $(arch) = x86
+            {
+                if $(addr) = 32 { linker-arch = x86 ; } else { linker-arch = x64 ; }
+            }
+            else if $(arch) = arm
+            {
+                if $(addr) = 32 { linker-arch = arm ; } else { linker-arch = arm64 ; }
+            }
+
+            local cond = "$(condition)/<architecture>$(arch)/<address-model>$(addr)" ;
+            if $(addr) = $(default-addr) && $(arch) = x86
+            {
+                cond += "$(condition)/<architecture>/<address-model>" ;
+                cond += "$(condition)/<architecture>/<address-model>$(addr)" ;
+                cond += "$(condition)/<architecture>$(arch)/<address-model>" ;
+            }
+
+            toolset.flags clang-win.compile .CC $(cond) : $(compiler) --target=$(clang-arch)-pc-windows-msvc ;
+            toolset.flags clang-win.link .LD $(cond) : $(linker) /nologo "/machine:$(linker-arch)" ;
+            toolset.flags clang-win.link LINKOPT $(cond) : ;
+            toolset.flags clang-win.link LINKFLAGS $(cond) : "/incremental:no" "/manifest" ;
+            if $(arch) = x86
+            {
+                toolset.flags clang-win.compile .ASM $(cond) : $(assembler) -nologo -c -Zp4 -Cp -Cx ;
+                toolset.flags clang-win.compile .ASM_OUTPUT $(cond) : -Fo ;
+            }
+            else if $(arch) = arm
+            {
+                toolset.flags clang-win.compile .ASM $(cond) : $(assembler) -machine $(arch) ;
+                toolset.flags clang-win.compile .ASM_OUTPUT $(cond) : -o ;
+            }
+            toolset.flags clang-win.archive .LD $(cond) : $(archiver) /nologo ;
+            toolset.flags clang-win.link .MT $(cond) : $(manifest-tool) -nologo ;
+            toolset.flags clang-win.compile .MC $(cond) : $(mc-compiler) ;
+            toolset.flags clang-win.compile .RC $(cond) : $(resource-compiler) ;
+            toolset.flags clang-win.compile .IDL $(cond) : $(idl-compiler) ;
         }
-
-        manifest-tool ?= mt.exe ;
-        resource-compiler ?= rc.exe ;
-        mc-compiler ?= mc.exe ;
-        idl-compiler ?= midl.exe ;
-
-        .notice "$(addr):" "using manifest-tool '$(manifest-tool)'" ;
-        .notice "$(addr):" "using resource-compiler '$(resource-compiler)'" ;
-        .notice "$(addr):" "using mc-compiler '$(mc-compiler)'" ;
-        .notice "$(addr):" "using idl-compiler '$(idl-compiler)'" ;
-
-        local cond = "$(condition)/<architecture>/<address-model>$(addr)" "$(condition)/<architecture>x86/<address-model>$(addr)" ;
-        if $(addr) = $(default-addr) { cond += "$(condition)/<architecture>/<address-model>" "$(condition)/<architecture>x86/<address-model>" ; }
-
-        toolset.flags clang-win.compile .CC $(cond) : $(compiler) -m$(addr) ;
-        toolset.flags clang-win.link .LD $(cond) : $(compiler) -m$(addr) ;
-        toolset.flags clang-win.link LINKOPT $(cond) : /link ;
-        toolset.flags clang-win.link LINKFLAGS $(cond) : "/incremental:no" "/manifest" ;
-        toolset.flags clang-win.compile .ASM $(cond) : $(assembler) -nologo -c -Zp4 -Cp -Cx ;
-        toolset.flags clang-win.compile .ASM_OUTPUT $(cond) : -Fo ;
-        toolset.flags clang-win.archive .LD $(cond) : $(archiver) /nologo ;
-        toolset.flags clang-win.link .MT $(cond) : $(manifest-tool) -nologo ;
-        toolset.flags clang-win.compile .MC $(cond) : $(mc-compiler) ;
-        toolset.flags clang-win.compile .RC $(cond) : $(resource-compiler) ;
-        toolset.flags clang-win.compile .IDL $(cond) : $(idl-compiler) ;
     }
 
     toolset.flags clang-win.link LIBRARY_OPTION <toolset>clang-win : "" : unchecked ;


### PR DESCRIPTION
## Proposed changes

MSVC besides x86/x64 also supports arm/arm64 target CPUs. Clang-cl can mimic this behavior to some extent. However, arm-related code was missing in `clang-win.jam`. The proposed patch also iterates over CPU architectures (`x86`, `arm` that is) and adds configurations for all possible combinations of (`architecture`, `address-model`).

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [ ] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [ ] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

The patch is tested with MS Visual Studio 2017, clang-cl 11.0.1, and boost 1.76.0. Naturally, nothing has changed for x86 and x64 configs. Arm64 target now also builds (except for `boost::context` which is not supported in MSVC-arm64 config either). However, as of clang-cl 11.0.1 building for arm target (address-model=32) fails with errors like this:

```
fatal error: error in backend: target does not implement codeview register mapping
PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace, preprocessed source, and associated run script.
Stack dump:
0.  Program arguments: C:/tools/LLVM/bin/clang-cl.exe --target=arm-pc-windows-msvc libs\atomic\config\has_synchronization.cpp -Fobin.v2\libs\atomic\config\23149ebc5dbeb01ab5ed2c6a496eb733\has_synchronization.obj -TP /EHs /GR /Z7 /Od /Ob0 /W3 /MDd -c -DBOOST_ALL_NO_LIB=1 -I.
....lengthy stack trace....
```

It looks like clang-cl doesn't support `arm-pc-windows-msvc` target yet (and it's not clear whether it ever will) but I don't see a point in disabling this configuration in `clang-win.jam`. The clang-cl error message is pretty clear to scare away those who will try to follow this path.