### PR TITLE
Allow only suffixes starting with a digit

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -151,7 +151,7 @@ test_toolset ()
 #
 check_toolset ()
 {
-    TOOLSET=${B2_TOOLSET%%-*}
+    TOOLSET=${B2_TOOLSET%%-[0-9]*}
     TOOLSET_SUFFIX=${B2_TOOLSET##$TOOLSET}
 
     # Prefer Clang (clang) on macOS..


### PR DESCRIPTION
An easiest way to ignore toolset platform subfeature suffixes (-linux/darwin/win).

Closes #76