### PR TITLE
Add Boost.Json to contrib/boost.jam

### DIFF
--- a/src/contrib/boost.jam
+++ b/src/contrib/boost.jam
@@ -213,6 +213,7 @@ rule boost_std ( inc ? lib ? )
     boost_lib_std graph               : BOOST_GRAPH_DYN_LINK ;
     boost_lib_std graph_parallel      : BOOST_GRAPH_DYN_LINK ;
     boost_lib_std iostreams           : BOOST_IOSTREAMS_DYN_LINK ;
+    boost_lib_std json                : BOOST_JSON_DYN_LINK ;
     boost_lib_std locale              : BOOST_LOCALE_DYN_LINK ;
     boost_lib_std log                 : BOOST_LOG_DYN_LINK  ;
     boost_lib_std log_setup           : BOOST_LOG_SETUP_DYN_LINK  ;


### PR DESCRIPTION
## Proposed changes

This change allows users of contrib/boost.jam to link to Boost.Json via the target `/boost//json`.
Fixes boostorg/build#733

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [X] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [X] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [X] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [X] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)