### PR TITLE
Do not unconditionally define unix on OpenBSD.

### DIFF
--- a/src/engine/jam.h
+++ b/src/engine/jam.h
@@ -328,7 +328,9 @@
 #ifdef __OpenBSD__
     #define OSMINOR "OS=OPENBSD"
     #define OS_OPENBSD
-    #define unix
+    #ifndef unix
+        #define unix
+    #endif
 #endif
 #if defined (__FreeBSD_kernel__) && !defined(__FreeBSD__)
     #define OSMINOR "OS=KFREEBSD"


### PR DESCRIPTION
This resolves a warning that popped up when we switched to Clang as
Clang defines unix in addition to __unix__ unlike GCC.