### PR TITLE
comment out NOENTRY flag of suppress-import-lib feature under MSVC

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1985,8 +1985,6 @@ local rule register-toolset-really ( )
         toolset.flags msvc.link FINDLIBS_SA <find-shared-library> ;
         toolset.flags msvc.link LIBRARY_OPTION <toolset>msvc : "" : unchecked ;
         toolset.flags msvc.link LIBRARIES_MENTIONED_BY_FILE : <library-file> ;
-
-        toolset.flags msvc.link.dll LINKFLAGS <suppress-import-lib>true : /NOENTRY ;
     }
 
     toolset.flags msvc.archive AROPTIONS <archiveflags> ;


### PR DESCRIPTION
Commits in https://github.com/boostorg/build/pull/28 adds a `/NOENTRY` flag for feature `<suppress-import-lib>` under MSVC, which is a flag that prevents DLL from linking to C runtime. However, when b2 uses MSVC, there are (at least) two cases that an import lib is not expected:

1. A resource only DLL, with no codes in it.
2. A DLL with codes and no exports, e.g. a plugin DLL such as a python `pyd` extension.

As far as I can infer, those commits mentioned above was primarily intended for case 1, and the `/NOENTRY` flag added won't work for case 2. However, `rule python-extension` togged `<suppress-import-lib>` feature on and was expecting it could be used as case 2, eventually causing build errors like what mentioned in https://github.com/boostorg/build/issues/734 .

In general it seems to blame `<suppress-import-lib>` for not being able to distinguish between those 2 cases. However, for a temporary fix, this PR proposes to remove `/NOENTRY` for `<suppress-import-lib>` to make it work for case 2 for now, and waits to see if it breaks something in the future. In case that it does break in the future, we could then consider preparing two separate features for different cases.

Fixes https://github.com/boostorg/build/issues/734