### PR TITLE
Use 64-bit MSVC tools on 64-bit host

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1446,7 +1446,7 @@ local rule configure-really ( version ? : options * )
                     vcvarsall.bat ] ;
             }
 
-            local default-setup-amd64 = vcvarsx86_amd64.bat ;
+            local default-setup-amd64 = vcvars64.bat ;
             local default-setup-i386  = vcvars32.bat ;
             local default-setup-ia64  = vcvarsx86_ia64.bat ;
             local default-setup-arm   = vcvarsx86_arm.bat ;


### PR DESCRIPTION


## Proposed changes

Perhaps this is supposed to be happening some other way with the current code, but for me I'm getting vcvarsx86_amd64.bat for my setup script for MSVC 14.2 on 64-bit Windows 10. I haven't tested with older VC versions.

## Types of changes

Very basic change of default VC batch script option from x86 to x64 tools.

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

It's a bugfix for MSVC 14.2, but it might break older versions, I'm not sure.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [ ] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

I'm happy to see this implemented in an alternate way, but AFAIK the default with modern VC versions should definitely be to use x64 tools on x64 hosts.
