### PR TITLE
Wrongly try to link b2 statically with intel-linux

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -327,16 +327,10 @@ case "${B2_TOOLSET}" in
         B2_CXXFLAGS_DEBUG="-O0 -g"
     ;;
 
-    intel-linux)
-        CXX_VERSION_OPT=${CXX_VERSION_OPT:---version}
-        B2_CXXFLAGS_RELEASE="-O3"
-        B2_CXXFLAGS_DEBUG="-O0 -g -p"
-    ;;
-
     intel-*)
         CXX_VERSION_OPT=${CXX_VERSION_OPT:---version}
-        B2_CXXFLAGS_RELEASE="-O3 -s -static"
-        B2_CXXFLAGS_DEBUG="-O0 -g -p -static"
+        B2_CXXFLAGS_RELEASE="-O3 -static-intel"
+        B2_CXXFLAGS_DEBUG="-O0 -g -static-intel"
     ;;
 
     vacpp)

--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -327,6 +327,12 @@ case "${B2_TOOLSET}" in
         B2_CXXFLAGS_DEBUG="-O0 -g"
     ;;
 
+    intel-linux)
+        CXX_VERSION_OPT=${CXX_VERSION_OPT:---version}
+        B2_CXXFLAGS_RELEASE="-O3"
+        B2_CXXFLAGS_DEBUG="-O0 -g -p"
+    ;;
+
     intel-*)
         CXX_VERSION_OPT=${CXX_VERSION_OPT:---version}
         B2_CXXFLAGS_RELEASE="-O3 -s -static"


### PR DESCRIPTION
refs #132 

On linux, the archive version of libstdc++ availability cannot be assumed.

So we cannot use the -static option.
Also, -s is not documented in the compiler manual page.

## Proposed changes

Propose a specialized configuration for intel-linux (leave the general intel as it is) that does not use the problemantic option.
Right now, the bug is preventing build on all intel-linux I have access to.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [ x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes (b2 is build that way)
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
