### PR TITLE
add .ipp files to scanner so headers are not missed

### DIFF
--- a/src/tools/types/cpp.jam
+++ b/src/tools/types/cpp.jam
@@ -76,6 +76,7 @@ scanner.register c-scanner : include ;
 type.register CPP : cpp cxx cc ;
 type.register H   : h ;
 type.register HPP : hpp : H ;
+type.register IPP : ipp : HPP ;
 type.register C   : c ;
 
 # It most cases where a CPP file or a H file is a source of some action, we
@@ -88,3 +89,5 @@ type.set-scanner C   : c-scanner ;
 # header.
 type.set-scanner H   : c-scanner ;
 type.set-scanner HPP : c-scanner ;
+# Private implementation files need scanning too.
+type.set-scanner IPP : c-scanner ;

--- a/src/tools/types/cpp.py
+++ b/src/tools/types/cpp.py
@@ -7,4 +7,5 @@ from b2.build import type as type_
 type_.register_type('CPP', ['cpp', 'cxx', 'cc'])
 type_.register_type('H', ['h'])
 type_.register_type('HPP', ['hpp'], 'H')
+type_.register_type('IPP', ['ipp'], 'HPP')
 type_.register_type('C', ['c'])


### PR DESCRIPTION
## Proposed changes

Refer to https://github.com/boostorg/build/issues/736; originally it was thought the root cause of that issue was that ".ipp" files were not being scanned for dependencies.  The behavior was that at some point during the build, it failed because <boost/bind.hpp> was not symlinked into the header directory in time.  Though further investigation found that the headers were obscured from the scanner by placing the filename in a #define, it still seems reasonable that ".ipp" files should be scanned for includes to build a proper dependency graph.

## Types of changes

* Scan .ipp files for header dependencies.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

