### PR TITLE
Update latest cxxstd version for recent gcc and clang

### DIFF
--- a/src/tools/clang.jam
+++ b/src/tools/clang.jam
@@ -55,7 +55,8 @@ rule init-cxxstd-flags ( toolset : condition * : version )
     local dialects = [ feature.values <cxxstd-dialect> ] ;
     dialects = [ set.difference $(dialects) : gnu iso ] ;
     local std ;
-    if [ version-ge $(version) : 10.0 ] { std = 20 ; }
+    if [ version-ge $(version) : 12.0 ] { std = 2b ; }
+    else if [ version-ge $(version) : 10.0 ] { std = 20 ; }
     else if [ version-ge $(version) : 6.0 ] { std = 2a ; }
     else if [ version-ge $(version) : 5.0 ] { std = 17 ; }
     else if [ version-ge $(version) : 3.5 ] { std = 1z ; }

--- a/src/tools/features/cxxstd-feature.jam
+++ b/src/tools/features/cxxstd-feature.jam
@@ -9,15 +9,15 @@ import feature ;
 
 [[bbv2.builtin.features.cxxstd]]`cxxstd`::
 *Allowed values*: `98`, `03`, `0x`, `11`, `1y`, `14`, `1z`, `17`, `2a`, `20`,
-`latest`.
+`2b`, `23`, `2c`, `26`, `latest`.
 +
 Specifies the version of the C++ Standard Language to build with. All the
 official versions of the standard since "98" are included.  It is also possible
 to specify using the experimental, work in progress, `latest` version. Some
 compilers specified intermediate versions for the experimental versions leading
 up to the released standard version. Those are included following the GNU
-nomenclature as `0x`, `1y`, `1z`, and `2a`. Depending on the compiler `latest`
-would map to one of those.
+nomenclature as `0x`, `1y`, `1z`, `2a`, `2b` and `2c`. Depending on the compiler
+`latest` would map to one of those.
 
 NOTE: This is an `optional` feature. Hence when not specified the compiler
 default behaviour is used.

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -430,7 +430,8 @@ local rule compile-link-flags ( * )
     local rule init-cxxstd-flags ( condition * : version )
     {
         local std ;
-        if [ version-ge $(version) : 10 ] { std = 20 ; }
+        if [ version-ge $(version) : 11 ] { std = 23 ; }
+        else if [ version-ge $(version) : 10 ] { std = 20 ; }
         else if [ version-ge $(version) : 8 ] { std = 2a ; }
         else if [ version-ge $(version) : 6 ] { std = 17 ; }
         else if [ version-ge $(version) : 5 ] { std = 1z ; }


### PR DESCRIPTION
## Proposed changes

Update compiler flags for `cxxstd=latest` for gcc and clang. Also update docs for `cxxstd`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [ ] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [ ] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [ ] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)
