### PR TITLE
Fix ODR violations

### DIFF
--- a/src/engine/function.cpp
+++ b/src/engine/function.cpp
@@ -213,11 +213,11 @@ typedef struct _jam_function
 } JAM_FUNCTION;
 
 
+namespace
+{
 typedef struct _stack STACK;
 typedef STACK* stack_ptr;
 
-namespace
-{
     template <typename T>
     using remove_cref_t
         = typename std::remove_const<
@@ -260,7 +260,6 @@ namespace
         typename select_last_impl<(sizeof...(A) == 1), type_list<A...> >
             ::template type<A...>;
     #endif
-}
 
 struct _stack
 {
@@ -437,6 +436,8 @@ void _stack::cleanup_push( int32_t n, T*_ )
 {
     std::uninitialized_fill_n( &cleanups[cleanups_size], n, (cleanup_f)&_stack::cleanup_item<T> );
     cleanups_size += n;
+}
+
 }
 
 static STACK * stack_global()

--- a/src/engine/make1.cpp
+++ b/src/engine/make1.cpp
@@ -86,6 +86,7 @@ static struct
 #define T_STATE_MAKE1B  1  /* make1b() should be called */
 #define T_STATE_MAKE1C  2  /* make1c() should be called */
 
+namespace {
 typedef struct _state state;
 struct _state
 {
@@ -94,6 +95,7 @@ struct _state
     TARGET * parent;    /* parent argument necessary for MAKE1A */
     int32_t  curstate;  /* current state */
 };
+}
 
 static void make1a( state * const );
 static void make1b( state * const );


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/858320

## Proposed changes

`struct _stack` is used in two different translation units with differing definitions. This violates ODR and breaks LTO.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [x] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I added necessary documentation (if appropriate)

## Further comments

Logs:
```
> x86_64-pc-linux-gnu-g++ -O2 -pipe -march=x86-64 -frecord-gcc-switches -fno-diagnostics-color -fmessage-length=0 -flto -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DNDEBUG -Wl,-O1 -Wl,--as-needed -Wl,--hash-style=gnu -Wl,--sort-common -Wl,--defsym=__gentoo_check_ldflags__=1 builtins.cpp class.cpp command.cpp compile.cpp constants.cpp cwd.cpp debug.cpp debugger.cpp execcmd.cpp execnt.cpp execunix.cpp filesys.cpp filent.cpp fileunix.cpp frames.cpp function.cpp glob.cpp hash.cpp hcache.cpp hdrmacro.cpp headers.cpp jam_strings.cpp jam.cpp jamgram.cpp lists.cpp make.cpp make1.cpp md5.cpp mem.cpp modules.cpp native.cpp object.cpp option.cpp output.cpp parse.cpp pathnt.cpp pathsys.cpp pathunix.cpp regexp.cpp rules.cpp scan.cpp search.cpp startup.cpp subst.cpp sysinfo.cpp timestamp.cpp variable.cpp w32_getreg.cpp modules/order.cpp modules/path.cpp modules/property-set.cpp modules/regex.cpp modules/sequence.cpp modules/set.cpp -o b2
function.cpp:265:8: error: type ‘struct _stack’ violates the C++ One Definition Rule [-Werror=odr]
  265 | struct _stack
      |        ^
make1.cpp:106:16: note: a different type is defined in another translation unit
  106 | typedef struct _stack
      |                ^
function.cpp:336:12: note: the first difference of corresponding definitions is field ‘start’
  336 |     void * start = nullptr;
      |            ^
make1.cpp:108:13: note: a field with different name is defined in another translation unit
  108 |     state * stack;
      |             ^
lto1: some warnings being treated as errors
lto-wrapper: fatal error: x86_64-pc-linux-gnu-g++ returned 1 exit status
compilation terminated.
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
```
