### PR TITLE
Fix B2 builds with non-MSVC compilers on Windows

### DIFF
--- a/src/engine/guess_toolset.bat
+++ b/src/engine/guess_toolset.bat
@@ -24,11 +24,28 @@ call :Clear_Error
 setlocal
 set test=%~$PATH:1
 endlocal
-if not errorlevel 1 set FOUND_PATH=%~dp$PATH:1
+if not "%test%" == "" set FOUND_PATH=%~dp$PATH:1
 goto :eof
 
 
 :Guess
+REM Check the PATH for non-MSVC compilers before calling up vswhere.
+call :Test_Path bcc32c.exe
+if not "%FOUND_PATH%" == "" (
+    set "B2_TOOLSET=borland"
+    set "B2_TOOLSET_ROOT=%FOUND_PATH%..\"
+    echo %FOUND_PATH%
+    exit /b 0)
+call :Test_Path icl.exe
+if not "%FOUND_PATH%" == "" (
+    set "B2_TOOLSET=intel-win32"
+    set "B2_TOOLSET_ROOT=%FOUND_PATH%..\"
+    exit /b 0)
+call :Test_Path gcc.exe
+if not "%FOUND_PATH%" == "" (
+    set "B2_TOOLSET=gcc"
+    set "B2_TOOLSET_ROOT=%FOUND_PATH%..\"
+    exit /b 0)
 REM Let vswhere tell us where msvc is at, if available.
 call :Clear_Error
 call vswhere_usability_wrapper.cmd
@@ -88,20 +105,6 @@ if not errorlevel 1 (
     set "B2_TOOLSET=msvc"
     call "%FOUND_PATH%VCVARS32.BAT"
     set "B2_TOOLSET_ROOT=%MSVCDir%\"
-    exit /b 0)
-call :Test_Path bcc32c.exe
-if not errorlevel 1 (
-    set "B2_TOOLSET=borland"
-    set "B2_TOOLSET_ROOT=%FOUND_PATH%..\"
-    exit /b 0)
-call :Test_Path icl.exe
-if not errorlevel 1 (
-    set "B2_TOOLSET=intel-win32"
-    set "B2_TOOLSET_ROOT=%FOUND_PATH%..\"
-    exit /b 0)
-if EXIST "C:\MinGW\bin\gcc.exe" (
-    set "B2_TOOLSET=mingw"
-    set "B2_TOOLSET_ROOT=C:\MinGW\"
     exit /b 0)
 REM Could not find a suitable toolset
 exit /b 1


### PR DESCRIPTION
## Proposed changes

This commit enables building B2 with non-MSVC compilers, without access to a MSYS2 shell.  Previously, the existence of a MSVC install would always override the specified PATH, making the user unable to build B2 unless they installed a MSYS2 environment separately.

This PR changes the behaviour by ensuring that the non-MSVC compilers are always checked first before falling back to vswhere.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [X] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [X] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [X] I added necessary documentation (if appropriate)

## Further comments

We are already shipping this change in Krita since 5.1 (https://invent.kde.org/graphics/krita/-/commit/629fd3de2961ac2cc91bcfc05ef90d2793d09bac) to great success.