### PR TITLE
Add Boost.URL

### DIFF
--- a/src/contrib/boost.jam
+++ b/src/contrib/boost.jam
@@ -237,6 +237,7 @@ rule boost_std ( inc ? lib ? )
     boost_lib_std thread              : BOOST_THREAD_DYN_DLL  ;
     boost_lib_std timer               : BOOST_TIMER_DYN_DLL  ;
     boost_lib_std unit_test_framework : BOOST_TEST_DYN_LINK  ;
+    boost_lib_std url                 : BOOST_URL_DYN_LINK  ;
     boost_lib_std wave                : BOOST_WAVE_DYN_LINK  ;
     boost_lib_std wserialization      : BOOST_SERIALIZATION_DYN_LINK ;
 }


### PR DESCRIPTION
## Proposed changes

I want to use Boost.URL with Boost 1.81

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments
