### PR TITLE
Add support for native msvc compilers on ARM64

### DIFF
--- a/src/engine/jam.h
+++ b/src/engine/jam.h
@@ -425,8 +425,13 @@
 #endif
 
 #if defined( __arm__ ) || \
-    defined( __aarch64__ )
+    defined( _M_ARM )
     #define OSPLAT "OSPLAT=ARM"
+#endif
+
+#if defined( __aarch64__ ) || \
+    defined( _M_ARM64 )
+    #define OSPLAT "OSPLAT=ARM64"
 #endif
 
 #ifdef __s390__

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -170,6 +170,9 @@ accepted only by AMD64 targeting compilers, cause the generated code to
 be tuned to a specific flavor of 64-bit x86. B2 will make use
 of those options depending on the value of the`instruction-set` feature.
 
+Starting with version 14.0, Microsoft Visual Studio can generate binaries
+using native arm64 tools to compile for x86, x86_64, and arm64.
+
 [[bbv2.reference.tools.compiler.msvc.winrt]]
 == Windows Runtime support
 
@@ -1510,6 +1513,14 @@ local rule configure-really ( version ? : options * )
             {
                 default-global-setup-options-ia64 = ia64 ;
             }
+            # When using ARM64 Windows, it is possible to use native compilers,
+            # selected by the parameters to vcvarsall.bat.
+            if [ MATCH ^(ARM64) : [ os.environ PROCESSOR_ARCHITECTURE ] ]
+            {
+                default-global-setup-options-arm64 = arm64 ;
+                default-global-setup-options-amd64 = arm64_x64 ;
+                default-global-setup-options-i386 = arm64_x86 ;
+            }
 
             for local c in $(cpu)
             {
@@ -2118,6 +2129,7 @@ switch $(.default-cpu-arch)
 {
     case x86   : .default-cpu-arch = i386 ;
     case em64t : .default-cpu-arch = amd64 ;
+    case arm64 : .default-cpu-arch = arm64 ;
 }
 
 for local cpu in $(.cpus-on-$(.cpu-arch-info-$(.default-cpu-arch)[1]))


### PR DESCRIPTION
## Proposed changes

Visual Studio 2022 provides native compilers for ARM64. This change detects and uses those native compilers.
I've also updated the OSPLAT definition to accept MSVC-specific constants _M_ARM and _M_ARM64. It made sense to split ARM/ARM64 at this point, since it's actually a significantly different architecture.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [x] I added necessary documentation (if appropriate)

## Further comments

I originally authored this against boostorg/build, and have validated the change on that tree by building some software via vcpkg using the change. I was unable to run the test suite before/after my change due to environment issues (the msvc tests for some reason depend on gcc?)
