### PR TITLE
A few fixes to PCH

### DIFF
--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -611,7 +611,7 @@ toolset.flags gcc.compile PCH_FILE <pch>on : <pch-file> ;
 
 actions compile.c++.pch
 {
-    "$(CONFIG_COMMAND)" -x c++-header $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -c -o "$(<)" "$(>)"
+    "$(CONFIG_COMMAND)" -x c++-header -ftemplate-depth-$(TEMPLATE_DEPTH) $(OPTIONS) $(USER_OPTIONS) -D$(DEFINES) -I"$(INCLUDES)" -include"$(FORCE_INCLUDES)" -c -o "$(<)" "$(>)"
 }
 
 actions compile.c.pch

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -737,12 +737,12 @@ toolset.flags msvc YLOPTION : "-Yl" ;
 #
 actions compile-c-c++ bind PDB_NAME PCH_HEADER
 {
-    $(.SETUP) $(.CC) @($(<[1]:W).rsp:O=FC:<=@":>=":E="$(>[1]:W)" -c -Fo"$(<[1]:W)" $(PDB_CFLAG)"$(PDB_NAME)" -FI"$(PCH_HEADER)" -Yu"$(>[3]:D=)" -Fp"$(>[2]:W)" $(CC_RSPLINE)) $(.CC.FILTER)
+    $(.SETUP) $(.CC) @($(<[1]:W).rsp:O=FC:<=@":>=":E="$(>[1]:W)" -c -Fo"$(<[1]:W)" $(PDB_CFLAG)"$(PDB_NAME)" -I"$(PCH_HEADER:D)" -FI"$(PCH_HEADER:D=)" -Yu"$(>[3]:D=)" -Fp"$(>[2]:W)" $(CC_RSPLINE)) $(.CC.FILTER)
 }
 
 actions preprocess-c-c++ bind PDB_NAME PCH_HEADER
 {
-    $(.SETUP) $(.CC) @($(<[1]:W).rsp:O=FC:<=@":>=":E="$(>[1]:W)" -P -Fi"$(<[1]:W)" $(PDB_CFLAG)"$(PDB_NAME)" -FI"$(PCH_HEADER)" -Yu"$(>[3]:D=)" -Fp"$(>[2]:W)" $(CC_RSPLINE))
+    $(.SETUP) $(.CC) @($(<[1]:W).rsp:O=FC:<=@":>=":E="$(>[1]:W)" -P -Fi"$(<[1]:W)" $(PDB_CFLAG)"$(PDB_NAME)" -I"$(PCH_HEADER:D)" -FI"$(PCH_HEADER:D=)" -Yu"$(>[3]:D=)" -Fp"$(>[2]:W)" $(CC_RSPLINE))
 }
 
 rule compile-c-c++ ( targets + : sources * )
@@ -769,7 +769,7 @@ rule preprocess-c-c++ ( targets + : sources * )
 # syntax highlighting in the messy N-quoted code below.
 actions compile-c-c++-pch
 {
-    $(.SETUP) $(.CC) @($(<[1]:W).rsp:O=FC:<=@":>=":E="$(>[2]:W)" -c -Fo"$(<[2]:W)" -Yc"$(>[1]:D=)" $(YLOPTION)"__bjam_pch_symbol_$(>[1]:D=)" -Fp"$(<[1]:W)" $(CC_RSPLINE)) @($(<[1]:W).cpp:<=":>=":E=$(.hash)include $(.escaped-double-quote)$(>[1]:D=)$(.escaped-double-quote)$(.nl)) $(.CC.FILTER)
+    $(.SETUP) $(.CC) @($(<[1]:W).rsp:O=FC:<=@":>=":E="$(>[2]:W)" -c -Fo"$(<[2]:W)" -I"$(>[1]:D)" -Yc"$(>[1]:D=)" $(YLOPTION)"__bjam_pch_symbol_$(>[1]:D=)" -Fp"$(<[1]:W)" $(CC_RSPLINE)) @($(<[1]:W).cpp:<=":>=":E=$(.hash)include $(.escaped-double-quote)$(>[1]:D=)$(.escaped-double-quote)$(.nl)) $(.CC.FILTER)
 }
 
 
@@ -778,7 +778,7 @@ actions compile-c-c++-pch
 # given as one of the source parameters.
 actions compile-c-c++-pch-s
 {
-    $(.SETUP) $(.CC) @($(<[1]:W).rsp:O=FC:<=@":>=":E="$(>[2]:W)" -c -Fo"$(<[2]:W)" -Yc"$(>[1]:D=)" $(YLOPTION)"__bjam_pch_symbol_$(>[1]:D=)" -Fp"$(<[1]:W)" $(CC_RSPLINE)) $(.CC.FILTER)
+    $(.SETUP) $(.CC) @($(<[1]:W).rsp:O=FC:<=@":>=":E="$(>[2]:W)" -c -Fo"$(<[2]:W)" -I"$(>[1]:D)" -Yc"$(>[1]:D=)" $(YLOPTION)"__bjam_pch_symbol_$(>[1]:D=)" -Fp"$(<[1]:W)" $(CC_RSPLINE)) $(.CC.FILTER)
 }
 
 
@@ -1002,14 +1002,13 @@ class msvc-pch-generator : pch-generator
 
         # If we do not have the PCH source - that is fine. We will just create a
         # temporary .cpp file in the action.
-        local pch-header-dir = [ $(pch-header).path ] ;
         local generated = [ generator.run $(project) $(name)
             : [ property-set.create
                 # Passing of <pch-source> is a dirty trick, needed because
                 # non-composing generators with multiple inputs are subtly
                 # broken. For more detailed information see:
                 # https://zigzag.cs.msu.su:7813/boost.build/ticket/111
-                <pch-source>$(pch-source) "<include>$(pch-header-dir)"
+                <pch-source>$(pch-source)
                 [ $(property-set).raw ] ]
             : $(pch-header) ] ;
 

--- a/test/BoostBuild.py
+++ b/test/BoostBuild.py
@@ -259,7 +259,7 @@ class Tester(TestCmd.TestCmd):
         if not executable:
             executable = os.getenv('B2')
         if not executable:
-            executable = 'b2'
+            executable = 'b2' if os.name != 'nt' else 'b2.exe'
 
         assert arguments.__class__ is not str
         self.original_workdir = os.path.dirname(__file__)

--- a/test/pch.py
+++ b/test/pch.py
@@ -15,9 +15,9 @@ t = BoostBuild.Tester()
 t.write("jamroot.jam", """
 import pch ;
 project : requirements <warnings-as-errors>on ;
-cpp-pch pch : pch.hpp ;
-cpp-pch pch-afx : pch.hpp : <define>HELLO ;
-cpp-pch pch-msvc-source : pch.hpp : <toolset>msvc:<source>pch.cpp ;
+cpp-pch pch : a/pch.hpp ;
+cpp-pch pch-afx : a/pch.hpp : <define>HELLO ;
+cpp-pch pch-msvc-source : a/pch.hpp : <toolset>msvc:<source>a/pch.cpp ;
 exe hello : hello.cpp pch ;
 exe hello-afx : hello-afx.cpp pch-afx : <define>HELLO ;
 exe hello-msvc-source : hello-msvc-source.cpp pch-msvc-source ;
@@ -31,9 +31,9 @@ public:
     TestClass( int, int ) {}
 };
 """
-t.write("pch.hpp", pch_content)
+t.write("a/pch.hpp", pch_content)
 
-t.write("pch.cpp", """#include <pch.hpp>
+t.write("a/pch.cpp", """#include <pch.hpp>
 """)
 
 toolset = BoostBuild.get_toolset()
@@ -52,10 +52,10 @@ t.expect_addition("bin/$toolset/debug*/hello-msvc-source.exe")
 # B2 will not recreate PCH, and compiler will happily use pre-compiled
 # header, not noticing that the real header is bad.
 
-t.rename("pch.hpp", "pch.hpp.orig")
+t.rename("a/pch.hpp", "a/pch.hpp.orig")
 s = "THIS WILL NOT COMPILE. "
-t.write("pch.hpp", s + (len(pch_content) - len(s)) * 'x')
-t.copy_timestamp("pch.hpp.orig", "pch.hpp")
+t.write("a/pch.hpp", s + (len(pch_content) - len(s)) * 'x')
+t.copy_timestamp("a/pch.hpp.orig", "a/pch.hpp")
 
 t.rm("bin/$toolset/debug*/hello.obj")
 t.rm("bin/$toolset/debug*/hello-afx.obj")


### PR DESCRIPTION
* MSVC: Fix PCH include directory
* MSVC: Pass only PCH-header name to -Yu
* GCC: Pass -ftemplate-depth-xxx when building PCH
* Test: Invoke b2 with .exe suffix on Windows

Fixes https://github.com/boostorg/boost/issues/711