### PR TITLE
clang-win: fix assembler path deducing

### DIFF
--- a/src/tools/clang-win.jam
+++ b/src/tools/clang-win.jam
@@ -104,13 +104,13 @@ rule init ( version ? : command * : options * )
         for local arch in x86 arm
         {
             local clang-arch ;
-            if $(arch) = x86
-            {
-                if $(addr) = 32 { clang-arch = i386 ; } else { clang-arch = x86_64 ; }
-            }
-            else if $(arch) = arm
-            {
-                if $(addr) = 32 { clang-arch = arm ; } else { clang-arch = aarch64 ; }
+            local target-assembler ;
+
+            switch $(arch)-$(addr) {
+            case x86-64 : clang-arch = x86_64  ; target-assembler = ml64 ;
+            case x86-32 : clang-arch = i386    ; target-assembler = ml ;
+            case arm-64 : clang-arch = aarch64 ; target-assembler = armasm64 ;
+            case arm-32 : clang-arch = arm     ; target-assembler = armasm ;
             }
 
             local config = [ SPLIT_BY_CHARACTERS [ SHELL "$(compiler) --target=$(clang-arch)-pc-windows-msvc -### foo.obj /link 2>&1" ] : "\n" ] ;
@@ -129,38 +129,17 @@ rule init ( version ? : command * : options * )
                 }
             }
 
-            local asm ;
-
-            if $(items)
-            {
-                asm = [ regex.replace $(items[1]) "x64\\\\link\\.exe" "x64\\ml64.exe" ] ;
-                asm = [ regex.replace $(asm) "x86\\\\link\\.exe" "x86\\ml.exe" ] ;
-                asm = [ regex.replace $(asm) "arm64\\\\link\\.exe" "arm64\\armasm64.exe" ] ;
-                asm = [ regex.replace $(asm) "arm\\\\link\\.exe" "arm\\armasm.exe" ] ;
-
-                if ! [ MATCH "(ml\\.exe)" "(ml64\\.exe)" "(armasm64\\.exe)" "(armasm\\.exe)" : $(asm) ]
-                {
-                    asm = ;
-                }
-            }
-
             local assembler = [ get-option "assembler" : $(addr) : $(options) ] ;
-            assembler ?= $(asm) ;
-            if $(arch) = x86
-            {
-                if $(addr) = 32 { assembler ?= ml.exe ; } else { assembler ?= ml64.exe ; }
-            }
-            else if $(arch) = arm
-            {
-                if $(addr) = 32 { assembler ?= armasm.exe ; } else { assembler ?= armasm64.exe ; }
-            }
-
             local linker ;
 
             if $(items)
             {
                 linker = [ regex.replace $(items[1]) "\\\\HostX64\\\\x86\\\\" "\\HostX86\\x86\\" ] ;
             }
+            if $(linker) {
+                assembler ?= $(linker:B=$(target-assembler)) ;
+            }
+            assembler ?= $(target-assembler) ;
 
             .notice "$(arch)-$(addr):" "using linker '$(linker)'" ;
 
@@ -246,7 +225,7 @@ rule init ( version ? : command * : options * )
             }
             else if $(arch) = arm
             {
-                toolset.flags clang-win.compile .ASM $(cond) : $(assembler) -machine $(arch) ;
+                toolset.flags clang-win.compile .ASM $(cond) : $(assembler) -nologo ;
                 toolset.flags clang-win.compile .ASM_OUTPUT $(cond) : -o ;
             }
             toolset.flags clang-win.archive .LD $(cond) : $(archiver) /nologo ;


### PR DESCRIPTION
* Assembler executable is located in the same directory as the `link.exe`.
* Added `-nologo` flag to armasm invocation.
* Removed `-machine` flag because it's not required and was wrongly passing `arm` where it should've been `arm64` leading to an error.

Blocks #224