### PR TITLE
fix openssl name handling

### DIFF
--- a/src/tools/openssl.jam
+++ b/src/tools/openssl.jam
@@ -43,8 +43,10 @@ if --debug-configuration in [ modules.peek : ARGV ]
 #
 #   <search>
 #       The directory containing the openssl binaries.
-#   <name>
-#       Overrides the default library name.
+#   <ssl-name>
+#       Overrides the default name of ssl library.
+#   <crypto-name>
+#       Overrides the default name of crypto library.
 #   <include>
 #       The directory containing the openssl headers.
 #
@@ -86,9 +88,10 @@ rule init (
 
     local library-path = [ feature.get-values <search> : $(options) ] ;
     local include-path = [ feature.get-values <include> : $(options) ] ;
-    local library-name = [ feature.get-values <name> : $(options) ] ;
+    local ssl-name = [ feature.get-values <ssl-name> : $(options) ] ;
+    local crypto-name = [ feature.get-values <crypto-name> : $(options) ] ;
 
-    if ! $(library-path) && ! $(include-path) && ! $(source-path) && ! $(library-name)
+    if ! $(library-path) && ! $(include-path) && ! $(source-path) && ! $(ssl-name) && ! $(crypto-name)
     {
         is-default = true ;
     }
@@ -122,15 +125,18 @@ rule init (
             }
         }
 
+        ssl-name ?= $(ssl_names) ;
+        crypto-name ?= $(crypto_names) ;
+
         local ssl_lib = [ new ac-library ssl : $(.project) : $(condition) :
-            $(include-path) : $(library-path) : ssl ] ;
+            $(include-path) : $(library-path) ] ;
         $(ssl_lib).set-header openssl/ssl.h ;
-        $(ssl_lib).set-default-names $(ssl_names) ;
+        $(ssl_lib).set-default-names $(ssl-name) ;
 
         local crypto_lib = [ new ac-library crypto : $(.project) : $(condition) :
-            $(include-path) : $(library-path) : crypto ] ;
+            $(include-path) : $(library-path) ] ;
         $(crypto_lib).set-header openssl/crypto.h ;
-        $(crypto_lib).set-default-names $(crypto_names) ;
+        $(crypto_lib).set-default-names $(crypto-name) ;
 
         targets.main-target-alternative $(ssl_lib) ;
         targets.main-target-alternative $(crypto_lib) ;


### PR DESCRIPTION
## Proposed changes

This PR makes it actually possible to override library names for openssl module. This is particularly relevant due to vcpkg creating `libcrypto.lib` not `crypto.lib`.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [X] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [X] I added myself to the copyright attributions for significant changes
- [X] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

Fix #107 