### PR TITLE
Fix compiler name for QNX

### DIFF
--- a/src/tools/qcc.jam
+++ b/src/tools/qcc.jam
@@ -38,7 +38,7 @@ toolset.inherit-rules qcc : unix ;
 rule init ( version ? : command * : options * )
 {
     local condition = [ common.check-init-parameters qcc : version $(version) ] ;
-    local command = [ common.get-invocation-command qcc : QCC : $(command) ] ;
+    local command = [ common.get-invocation-command qcc : qcc : $(command) ] ;
     common.handle-options qcc : $(condition) : $(command) : $(options) ;
 }
 


### PR DESCRIPTION
## Proposed changes

Change compiler name from "QCC" to "qcc". QNX uses "qcc", not "QCC".

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)