### PR TITLE
vcpkg module

### DIFF
--- a/doc/src/tasks.adoc
+++ b/doc/src/tasks.adoc
@@ -726,3 +726,7 @@ managers. Currently the supported ones are:
 
 * Conan (`conan`): currently supports the
   link:https://docs.conan.io/en/latest/reference/generators/b2.html[`b2 generator`].
+
+:leveloffset: +1
+include::../../src/tools/vcpkg.jam[tag=doc]
+:leveloffset: -1

--- a/src/build/ac.jam
+++ b/src/build/ac.jam
@@ -199,9 +199,17 @@ class ac-library : basic-target
         else
         {
             local use-environment ;
+            local vcpkg-ps ;
             if ! $(self.library-name) && ! $(self.include-path) && ! $(self.library-path)
             {
                 use-environment = true ;
+                local vcpkg-proj = [ project.target vcpkg : allow-missing ] ;
+                if $(vcpkg-proj)
+                {
+                    vcpkg-ps = [ targets.generate-from-reference
+                        /vcpkg//prefix : $(vcpkg-proj) : $(property-set) ] ;
+                }
+
             }
             local libnames = $(self.library-name) ;
             if ! $(libnames) && $(use-environment)
@@ -213,12 +221,20 @@ class ac-library : basic-target
             libnames ?= $(self.default-names) ;
 
             local include-path = $(self.include-path) ;
+            if ! $(include-path) && $(vcpkg-ps)
+            {
+                include-path = [ $(vcpkg-ps).get <include> ] ;
+            }
             if ! $(include-path) && $(use-environment)
             {
                 include-path = [ os.environ $(name:U)_INCLUDE ] ;
             }
 
             local library-path = $(self.library-path) ;
+            if ! $(library-path) && $(vcpkg-ps)
+            {
+                library-path = [ $(vcpkg-ps).get <search> ] ;
+            }
             if ! $(library-path) && $(use-environment)
             {
                 library-path = [ os.environ $(name:U)_LIBRARY_PATH ] ;

--- a/src/tools/vcpkg.jam
+++ b/src/tools/vcpkg.jam
@@ -1,0 +1,393 @@
+#|
+Copyright 2023 Dmitry Arkhipov (grisumbras@yandex.ru)
+Distributed under the Boost Software License, Version 1.0. (See
+accompanying file LICENSE.txt or copy at
+https://www.bfgroup.xyz/b2/LICENSE.txt)
+|#
+
+import errors ;
+import feature ;
+import msvc ;
+import os ;
+import path ;
+import project ;
+import property ;
+import targets ;
+
+#| tag::doc[]
+
+= vcpkg support
+https://learn.microsoft.com/vcpkg[vcpkg] is a cross-platform package manager
+for C and {CPP} developed by Microsoft. vcpkg provides first-class support
+for CMake and MSBuild build systems, but you can still use packages installed
+by vcpkg in b2 either as link:#bbv2.tutorial.prebuilt[prebuilt libraries],
+with the help of link:#_pkg_config[pkg-config] tool, or if the package provides
+a link:#bbv2.extending.toolset_modules[toolset module].
+
+The module declares the project `/vcpkg` with a main target `/vcpkg//prefix`.
+The target can be used as a dependency to add its `<include>` and `<search>`
+usage requirements.
+
+[source, jam]
+----
+lib sqlite3 : /vcpkg//prefix ;
+----
+
+|# # end::doc[]
+
+if --debug-configuration in [ modules.peek : ARGV ]
+{
+    .debug =  true ;
+}
+
+#| tag::doc[]
+
+
+== Initialization
+To enable vcpkg integration you need to declare it in a configuration file
+with the help of `using` rule:
+
+[source, jam]
+----
+using vcpkg : [options] ... : [ requirements ] ... ;
+----
+
+* `options`: options that specify the location of vcpkg package installation
+    tree. Allowed options are:
+
+    ** `<include>`: directory with header files;
+    ** `<search>`: directory with library binaries;
+    ** `<prefix>`: installation prefix for the triplet;
+    ** `<triplet>`: the triplet to use;
+    ** `<root>`: vcpkg installation root.
+
+* `requirements`: properties that distinguish this configuration.
+
+If options do contain neither `<include>` nor `<search>`, they are set
+to `include` and `lib` subdirectories of `<prefix>`.
+
+If options do not contain `<prefix>`, it is set to `<root>/<triplet>`.
+
+If options do not contain `<root>`, it is set to `installed` subdirectory of
+the directory pointed to by `VCPKG_ROOT` environment variable if it is not
+empty. Otherwise,
+https://learn.microsoft.com/vcpkg/users/manifests[Manisfest mode] is assumed,
+and `vcpkg.json` file is searched for in the current directory and its parents.
+If the file is found, then `<root>` is set to `vcpkg_installed` subdirectory
+of its parent directory.
+
+If options do not contain `<triplet>`, it is set to the value of
+`VCPKG_DEFAULT_TRIPLET` environment variable if it is not empty. Otherwise,
+if there is exactly one triplet subdirectory of `<root>` directory, then its
+name is used.
+
+If requirements do not contain a property of `<variant>`, and options do not
+contain `<search>`, then two versions are configured: one for
+`<variant>release` that sets `<search>` to `<prefix>/lib`, and another for
+`<variant>debug` that sets `<search>` to `<prefix>/debug/lib`.
+
+Finally, if options contain none of `<include>`, `<search>`, `<prefix>`, and
+`<triplet>` and requirements are empty, appropriate configurations for several
+default triplets provided by vcpkg are made.
+
+|# # end::doc[]
+
+rule init ( options * : requirements * )
+{
+    local incdir = [ feature.get-values <include> : $(options) ] ;
+    local libdir = [ feature.get-values <search> : $(options) ] ;
+    local prefix = [ feature.get-values <prefix> : $(options) ] ;
+    local root = [ feature.get-values <root> : $(options) ] ;
+    local triplet = [ feature.get-values <triplet> : $(options) ] ;
+
+    if ( ( $(root) || $(triplet) ) && ( $(prefix) || $(incdir) || $(libdir) ) )
+        || ( $(prefix) && ( $(incdir) || $(libdir) ) )
+        || ( $(incdir) && ! $(libdir) )
+        || ( $(libdir) && ! $(incdir) )
+    {
+        errors.user-error "incompatible options for vcpkg:" $(options) ;
+    }
+
+    local kind = predefined-triplets ;
+    if $(prefix) || $(incdir) || $(libdir)
+    {
+        kind = specific-triplet ;
+    }
+    else
+    {
+        if $(triplet) || $(requirements)
+        {
+            kind = specific-triplet ;
+        }
+    }
+
+    if ! $(.initialized)
+    {
+        .initialized = true ;
+
+        project.initialize $(__name__) ;
+        project $(__name__) ;
+    }
+    else
+    {
+        if ! $(options) && ! $(requirements)
+        {
+            kind = ;
+        }
+    }
+
+    local project = [ project.target $(__name__) ] ;
+
+    switch $(kind)
+    {
+        case predefined-triplets :
+            configure-predefined $(project) : $(root) ;
+        case specific-triplet :
+            configure-specific $(project) : $(root) : $(triplet) : $(prefix)
+                : $(incdir) : $(libdir) : $(requirements) ;
+    }
+}
+
+
+local rule configure-predefined ( project : root ? )
+{
+    if ! $(root)
+    {
+        root = [ deduce-root ] ;
+    }
+
+    # arm-neon-android, arm6-android, arm64ec-windows, wasm32-emscripten,
+    # all xbox, mingw, and -release triplets are skipped
+
+    # Linux
+    configure-specific $(project) : $(root) : x64-linux : : :
+        : <target-os>linux <link>static <runtime-link>shared ;
+    configure-specific $(project) : $(root) : x64-linux-dynamic : : :
+        : <target-os>linux <link>shared <runtime-link>shared ;
+
+    configure-specific $(project) : $(root) : x86-linux : : :
+        : <target-os>linux <address-model>32 <link>static <runtime-link>shared ;
+
+    configure-specific $(project) : $(root) : arm-linux : : :
+        : <target-os>linux <address-model>32 <architecture>arm <link>static <runtime-link>shared ;
+
+    configure-specific $(project) : $(root) : arm64-linux : : :
+        : <target-os>linux <architecture>arm <link>static <runtime-link>shared ;
+
+    configure-specific $(project) : $(root) : ppc64le-linux : : :
+        : <target-os>linux <architecture>power <link>static <runtime-link>shared ;
+
+    configure-specific $(project) : $(root) : riscv32-linux : : :
+        : <target-os>linux <address-model>32 <architecture>riscv <link>static <runtime-link>shared ;
+
+    configure-specific $(project) : $(root) : riscv64-linux : : :
+        : <target-os>linux <architecture>riscv <link>static <runtime-link>shared ;
+
+    configure-specific $(project) : $(root) : s390x-linux : : :
+        : <target-os>linux <architecture>s390x <link>static <runtime-link>shared ;
+
+    # Windows
+    configure-specific $(project) : $(root) : x64-windows : : :
+        : <target-os>windows <link>shared <runtime-link>shared <windows-api>desktop ;
+    configure-specific $(project) : $(root) : x64-windows-static : : :
+        : <target-os>windows <link>static <runtime-link>static <windows-api>desktop ;
+    configure-specific $(project) : $(root) : x64-windows-static-md : : :
+        : <target-os>windows <link>static <runtime-link>shared <windows-api>desktop ;
+
+    configure-specific $(project) : $(root) : x86-windows : : :
+        : <target-os>windows <address-model>32 <link>shared <runtime-link>shared <windows-api>desktop ;
+    configure-specific $(project) : $(root) : x86-windows-static-md : : :
+        : <target-os>windows <address-model>32 <link>static <runtime-link>shared <windows-api>desktop ;
+    configure-specific $(project) : $(root) : x86-windows-static : : :
+        : <target-os>windows <address-model>32 <link>static <runtime-link>static <windows-api>desktop ;
+
+    configure-specific $(project) : $(root) : arm64-windows : : :
+        : <target-os>windows <architecture>arm <link>shared <runtime-link>shared <windows-api>desktop ;
+    configure-specific $(project) : $(root) : arm64-windows-static-md : : :
+        : <target-os>windows <architecture>arm <link>static <runtime-link>shared <windows-api>desktop ;
+    configure-specific $(project) : $(root) : arm64-windows-static : : :
+        : <target-os>windows <architecture>arm <link>static <runtime-link>static <windows-api>desktop ;
+
+    configure-specific $(project) : $(root) : arm-windows : : :
+        : <target-os>windows <address-model>32 <architecture>arm <link>shared <runtime-link>shared <windows-api>desktop ;
+    configure-specific $(project) : $(root) : arm-windows-static : : :
+        : <target-os>windows <address-model>32 <architecture>arm <link>static <runtime-link>static <windows-api>desktop ;
+
+    # WindowsStore
+    configure-specific $(project) : $(root) : x64-uwp : : :
+        : <target-os>windows <link>shared <runtime-link>shared <windows-api>store ;
+    configure-specific $(project) : $(root) : x64-uwp-static-md : : :
+        : <target-os>windows <link>static <runtime-link>shared <windows-api>store ;
+
+    configure-specific $(project) : $(root) : x86-uwp : : :
+        : <target-os>windows <address-model>32 <link>shared <runtime-link>shared <windows-api>store ;
+    configure-specific $(project) : $(root) : x86-uwp-static-md : : :
+        : <target-os>windows <address-model>32 <link>static <runtime-link>shared <windows-api>store ;
+
+    configure-specific $(project) : $(root) : arm64-uwp : : :
+        : <target-os>windows <architecture>arm <link>shared <runtime-link>shared <windows-api>store ;
+    configure-specific $(project) : $(root) : arm64-uwp-static-md : : :
+        : <target-os>windows <architecture>arm <link>static <runtime-link>shared <windows-api>store ;
+
+    configure-specific $(project) : $(root) : arm-uwp : : :
+        : <target-os>windows <address-model>32 <architecture>arm <link>shared <runtime-link>shared <windows-api>store ;
+    configure-specific $(project) : $(root) : arm-uwp-static-md : : :
+        : <target-os>windows <address-model>32 <architecture>arm <link>static <runtime-link>shared <windows-api>store ;
+
+    # OSX
+    configure-specific $(project) : $(root) : x64-osx : : :
+        : <target-os>darwin <link>static <runtime-link>shared ;
+    configure-specific $(project) : $(root) : x64-osx-dynamic : : :
+        : <target-os>darwin <link>shared <runtime-link>shared ;
+
+    configure-specific $(project) : $(root) : arm64-osx-dynamic : : :
+        : <target-os>darwin <architecture>arm <link>shared <runtime-link>shared ;
+    configure-specific $(project) : $(root) : arm64-osx : : :
+        : <target-os>darwin <architecture>arm <link>static <runtime-link>shared ;
+
+    # Android
+    configure-specific $(project) : $(root) : x64-android : : :
+        : <target-os>android <link>static <runtime-link>static ;
+
+    configure-specific $(project) : $(root) : x86-android : : :
+        : <target-os>android <address-model>32 <link>static <runtime-link>static ;
+
+    configure-specific $(project) : $(root) : arm64-android : : :
+        : <target-os>android <architecture>arm <link>static <runtime-link>static ;
+
+    configure-specific $(project) : $(root) : arm-android : : :
+        : <target-os>android <address-model>32 <architecture>arm <link>static <runtime-link>static ;
+
+    # iPhone
+    configure-specific $(project) : $(root) : arm-ios : : :
+        : <target-os>iphone <address-model>32 <architecture>arm <link>static <runtime-link>shared ;
+
+    configure-specific $(project) : $(root) : arm64-ios : : :
+        : <target-os>iphone <architecture>arm <link>static <runtime-link>shared ;
+
+    configure-specific $(project) : $(root) : x64-ios : : :
+        : <target-os>iphone <link>static <runtime-link>shared ;
+
+    configure-specific $(project) : $(root) : x86-ios : : :
+        : <target-os>iphone <address-model>32 <link>static <runtime-link>shared ;
+
+    # FreeBSD
+    configure-specific $(project) : $(root) : x64-freebsd : : :
+        : <target-os>freebsd <link>static <runtime-link>shared ;
+
+    configure-specific $(project) : $(root) : x86-freebsd : : :
+        : <target-os>freebsd <address-model>32 <link>static <runtime-link>shared ;
+
+    # OpenBSD
+    configure-specific $(project) : $(root) : x64-openbsd : : :
+        : <target-os>openbsd <link>static <runtime-link>shared ;
+
+}
+
+local rule configure-specific ( project : root ? : triplet ? : prefix ?
+    : incdir ? : libdir ? : requirements + )
+{
+    if ! $(incdir) || ! $(libdir)
+    {
+        if ! $(prefix)
+        {
+            prefix = [ deduce-prefix $(root) : $(triplet) ] ;
+        }
+        incdir ?= [ path.join $(prefix) include ] ;
+        libdir ?= [ path.join $(prefix) lib ] ;
+        if ! [ property.select <variant> : $(requirements) ]
+        {
+            with-debug = true ;
+        }
+    }
+
+    if with-debug
+    {
+        declare-target $(project) : $(incdir) : $(libdir)
+            : $(requirements) <variant>release ;
+        declare-target $(project) : $(incdir)
+            : [ path.join $(prefix) debug/lib ]
+            : $(requirements) <variant>debug ;
+    }
+    else
+    {
+        declare-target $(project) : $(incdir) : $(libdir) : $(requirements) ;
+    }
+}
+
+local rule declare-target ( project : incdir : libdir : requirements * )
+{
+    if $(.debug)
+    {
+        echo "notice: [vcpkg] configuring with" <include>$(incdir)
+            <search>$(libdir) ;
+    }
+
+    targets.create-metatarget alias-target-class
+        : $(project)
+        : prefix
+        :
+        : $(requirements)
+        :
+        : <include>$(incdir)
+          <search>$(libdir)
+        ;
+}
+
+local rule deduce-prefix ( root ? : triplet ? )
+{
+    if ! $(root)
+    {
+        root = [ deduce-root ] ;
+    }
+
+    triplet ?= [ os.environ VCPKG_DEFAULT_TRIPLET ] ;
+    if ! $(triplet) && $(root)
+    {
+        local ignored = [ path.join $(root) vcpkg ] ;
+        for local p in [ path.glob $(root) : * ]
+        {
+            if $(p) != $(ignored)
+            {
+                triplet += $(p:B) ;
+            }
+        }
+        if $(triplet[2])
+        {
+            triplet = ;
+        }
+    }
+
+    if ! $(root) || ! $(triplet)
+    {
+        errors.user-error "could not initialize vcpkg module:"
+            "vcpkg installation could not be deduced" ;
+    }
+
+    return [ path.join $(root) $(triplet) ] ;
+}
+
+local rule deduce-root ( )
+{
+    # attempt to locate vcpkg installation using environment variable
+    local root = [ os.environ VCPKG_ROOT ] ;
+    if $(root)
+    {
+        root = [ path.join [ path.make $(root) ] installed ] ;
+    }
+    else
+    {
+        # check if Manifest mode is used
+        local roots = . [ path.all-parents . ] ;
+        while $(roots) && ! $(root)
+        {
+            if [ path.glob $(roots[1]) : vcpkg.json ]
+            {
+                root = $(roots[1])/vcpkg_installed ;
+            }
+            roots = $(roots[2-]) ;
+        }
+    }
+
+    return $(root) ;
+}


### PR DESCRIPTION
## Proposed changes

Adds a module for vcpkg support. The module provides target `/vcpkg//prefix` for manual searching for vcpkg-installed libraries. FIle `build/ac.jam` also changed to take advantage of vcpkg *if* it was configured. This will allow existing toolset modules for libraries to gain vcpkg support automatically.

 ## Types of changes

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [X] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [X] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [X] I added myself to the copyright attributions for significant changes
- [X] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [X] I added necessary documentation (if appropriate)

## Further comments

I haven't added any tests. Do I need to in this case?