### PR TITLE
test suite: msys/cygwin fixes

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,7 +17,8 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 cd "$pwd"
-cp "./src/engine/b2" .
+cp "./src/engine/b2" . 2>/dev/null
+cp "./src/engine/b2.exe" . 2>/dev/null
 
 cat << EOF
 

--- a/src/tools/link.jam
+++ b/src/tools/link.jam
@@ -229,8 +229,8 @@ class symlink-target-class : basic-target
 
 rule do-file-link
 {
-    local target = [ path.native [ path.relative-to [ path.pwd ] $(<) ] ] ;
-    local source = [ path.native [ path.relative-to [ path.pwd ] $(>) ] ] ;
+    local target = [ path.relative-to [ path.pwd ] $(<) ] ;
+    local source = [ path.relative-to [ path.pwd ] $(>) ] ;
     local old-source = [ on $(target) return $(LINK-SOURCE) ] ;
     if $(old-source)
     {
@@ -240,6 +240,8 @@ rule do-file-link
             Link previously defined to another file, $(old-source[1]). ;
     }
     LINK-SOURCE on $(target) = $(source) $(.current-target) ;
+    target = [ path.native $(target) ] ;
+    source = [ path.native $(source) ] ;
     LOCATE on $(target) = . ;
     DEPENDS $(.current-target) : $(target) ;
     if $(.can-symlink) = true

--- a/test/TestToolset.py
+++ b/test/TestToolset.py
@@ -119,7 +119,7 @@ def test_toolset(toolset, version, property_sets):
         t.run_build_system(["--user-config=", "-sPYTHON_CMD=%s" % sys.executable] + properties)
         t.expect_addition("bin/%s/lib.obj" % (path("obj")))
         if "link=static" not in properties:
-            if get_target_os(properties) in ["cygwin", "windows"] and toolset != "clang-linux":
+            if t.is_implib_expected():
                 t.expect_addition("bin/%s/l1.implib" % (path("dll")))
             t.expect_addition("bin/%s/l1.dll" % (path("dll")))
             t.ignore_addition("bin/%s/*l1.*.rsp" % (path("dll")))

--- a/test/builtin_readlink.py
+++ b/test/builtin_readlink.py
@@ -7,12 +7,14 @@
 import BoostBuild
 import os
 import sys
+from unittest.mock import patch
 
 t = BoostBuild.Tester(pass_toolset=0)
 
 t.write("link-target", "")
 try:
-    os.symlink("link-target", "link")
+    with patch.dict(os.environ, {var: "winsymlinks:nativestrict" for var in ["MSYS", "CYGWIN"]}):
+        os.symlink("link-target", "link")
 except (AttributeError, OSError) as e:
     # Either OS does not support symlinks or not enough privilege
     print("XFAIL: %s" % e)

--- a/test/library_chain.py
+++ b/test/library_chain.py
@@ -117,7 +117,7 @@ void a() {}
 t.run_build_system(subdir="a")
 t.expect_addition("a/dist/a.dll")
 
-if sys.platform == 'win32':
+if t.is_implib_expected():
     # This is a Windows import library.
     file = t.adjust_name("a.implib")
 else:

--- a/test/link.py
+++ b/test/link.py
@@ -8,6 +8,8 @@
 # common boost/ directory in the new git layout.
 
 import BoostBuild
+import os
+from unittest.mock import patch
 
 def ignore_config(t):
     """These files are created by the configuration logic in link.jam
@@ -339,12 +341,14 @@ def test_error_duplicate():
 
     t.cleanup()
 
-test_basic()
-test_merge_two()
-test_merge_existing_all()
-test_merge_recursive()
-test_merge_recursive_existing_all()
-test_include_scan()
-test_include_scan_merge_existing()
-test_update_file_link_all()
-test_error_duplicate()
+
+with patch.dict(os.environ, {var: "winsymlinks:nativestrict" for var in ["MSYS", "CYGWIN"]}):
+    test_basic()
+    test_merge_two()
+    test_merge_existing_all()
+    test_merge_recursive()
+    test_merge_recursive_existing_all()
+    test_include_scan()
+    test_include_scan_merge_existing()
+    test_update_file_link_all()
+    test_error_duplicate()

--- a/test/prebuilt/ext/jamfile2.jam
+++ b/test/prebuilt/ext/jamfile2.jam
@@ -18,7 +18,7 @@ if [ os.name ] in NT
 }
 else if [ os.name ] in CYGWIN
 {
-    dll-suffix = dll ;
+    dll-suffix = dll.a ;
 }
 else if [ os.name ] in MACOSX
 {

--- a/test/prebuilt/ext/jamfile3.jam
+++ b/test/prebuilt/ext/jamfile3.jam
@@ -22,7 +22,7 @@ if [ os.name ] in NT
 }
 else if [ os.name ] in CYGWIN
 {
-    dll-suffix = dll ;
+    dll-suffix = dll.a ;
 }
 else if [ os.name ] in MACOSX
 {

--- a/test/searched_lib.py
+++ b/test/searched_lib.py
@@ -31,8 +31,8 @@ t.expect_addition("lib/bin/$toolset/debug*/test_lib.dll")
 
 # Auto adjusting of suffixes does not work, since we need to
 # change dll to lib.
-if ( ( os.name == "nt" ) or os.uname()[0].lower().startswith("cygwin") ) and \
-    ( BoostBuild.get_toolset() != "gcc" ):
+if t.is_implib_expected():
+    t.expect_addition("lib/bin/$toolset/debug*/test_lib.implib")
     t.copy("lib/bin/$toolset/debug*/test_lib.implib", "lib/test_lib.implib")
     t.copy("lib/bin/$toolset/debug*/test_lib.dll", "lib/test_lib.dll")
 else:


### PR DESCRIPTION
3 tests still remain broken: core_language and toolset_msvc due to https://github.com/bfgroup/b2/issues/212, package due to an opposite of https://github.com/boostorg/boost_install/issues/32.

Btw, I was under impression that cygwin is tested in CI, but it turns out that job doesn't run tests.