### PR TITLE
CI: macos gcc tests runner

### DIFF
--- a/.ci/azp-macos-extra.yml
+++ b/.ci/azp-macos-extra.yml
@@ -7,16 +7,14 @@ steps:
     displayName: Install
   - bash: |
       set -e
-      CXX_PATH=`which ${CXX}`
-      echo "using ${TEST_TOOLSET} : : ${CXX_PATH} ;" > ${HOME}/user-config.jam
       ./bootstrap.sh ${TOOLSET}
-      ./b2 --prefix=$HOME/temp/.b2 install ${TEST_TOOLSET}
+      ./b2 --prefix=$HOME/temp/.b2 install ${TOOLSET:+toolset=$TOOLSET}
       rm ./b2
       export PATH=$HOME/temp/.b2/bin:$PATH
       cd $HOME
       touch build.jam
       b2 -v
-      b2 -n --debug-configuration
+      b2 -n --debug-configuration ${TOOLSET:+toolset=$TOOLSET}
     displayName: Bootstrap
   - { bash: "./.ci/b2_example.sh example/hello", displayName: "example/hello" }
   - { bash: "./.ci/b2_example.sh example/libraries", displayName: "example/libraries" }

--- a/.ci/azp-macos-test.yml
+++ b/.ci/azp-macos-test.yml
@@ -8,34 +8,28 @@ steps:
 - bash: |
     set -e
     cd src/engine
-    ./build.sh ${TOOLSET} --cxx=${CXX}
+    ./build.sh ${TOOLSET}
     ./b2 -v
     cd ../..
   displayName: Build
 - bash: |
     set -e
-    CXX_PATH=`which ${CXX}`
     cd test
-    echo "using ${TEST_TOOLSET} : : ${CXX_PATH} ;" > ${HOME}/user-config.jam
-    python test_all.py ${TEST_TOOLSET}
+    python test_all.py ${TOOLSET}
     cd ..
   displayName: Test
 - bash: |
     set -e
-    CXX_PATH=`which ${CXX}`
-    echo "using ${TEST_TOOLSET} : : ${CXX_PATH} ;" > ${HOME}/user-config.jam
-    ./src/engine/b2 b2 warnings-as-errors=on variant=debug,release address-model=32,64 toolset=${TEST_TOOLSET}
+    ./src/engine/b2 b2 warnings-as-errors=on variant=debug,release address-model=32,64 ${TOOLSET:+toolset=$TOOLSET}
   displayName: "No Warnings"
 - bash: |
     set -e
-    CXX_PATH=`which ${CXX}`
-    echo "using ${TEST_TOOLSET} : : ${CXX_PATH} ;" > ${HOME}/user-config.jam
     ./bootstrap.sh ${TOOLSET}
-    ./b2 --prefix=$HOME/temp/.b2 install ${TEST_TOOLSET}
+    ./b2 --prefix=$HOME/temp/.b2 install ${TOOLSET:+toolset=$TOOLSET}
     rm ./b2
     export PATH=$HOME/temp/.b2/bin:$PATH
     cd $HOME
     touch build.jam
     b2 -v
-    b2 -n --debug-configuration
+    b2 -n --debug-configuration ${TOOLSET:+toolset=$TOOLSET}
   displayName: Bootstrap

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,7 +103,8 @@ stages:
   - job: 'macOS'
     strategy:
       matrix:
-        Xcode ${{variables.xc_latest}}: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: "/Applications/Xcode_${{variables.xc_latest}}.app", VM_IMAGE: "${{variables.macos_latest_vm}}"}
+        Xcode ${{variables.xc_latest}}: {XCODE_APP: "/Applications/Xcode_${{variables.xc_latest}}.app", VM_IMAGE: "${{variables.macos_latest_vm}}"}
+        GCC ${{variables.gcc_latest}}: {TOOLSET: "gcc-${{variables.gcc_latest}}", XCODE_APP: "/Applications/Xcode_${{variables.xc_latest}}.app", VM_IMAGE: "${{variables.macos_latest_vm}}"}
     pool:
       vmImage: $(VM_IMAGE)
     steps:
@@ -129,15 +130,12 @@ stages:
       matrix:
         Xcode ${{variables.xc_latest}} arm+x86/64: {
           B2_ARGS: "architecture=arm+x86 address-model=64",
-          TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++,
           XCODE_APP: "/Applications/Xcode_${{variables.xc_latest}}.app", VM_IMAGE: "${{variables.macos_latest_vm}}"}
         Xcode ${{variables.xc_latest}} arm/64: {
           B2_ARGS: "architecture=arm address-model=64",
-          TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++,
           XCODE_APP: "/Applications/Xcode_${{variables.xc_latest}}.app", VM_IMAGE: "${{variables.macos_latest_vm}}"}
         Xcode ${{variables.xc_latest}} x86/64: {
           B2_ARGS: "architecture=x86 address-model=64",
-          TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++,
           XCODE_APP: "/Applications/Xcode_${{variables.xc_latest}}.app", VM_IMAGE: "${{variables.macos_latest_vm}}"}
     pool:
       vmImage: $(VM_IMAGE)
@@ -239,24 +237,24 @@ stages:
   - job: 'macOS'
     strategy:
       matrix:
-        # Xcode 13.4.1: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_13.4.1.app, VM_IMAGE: 'macOS-12'}
-        Xcode 13.3.1: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_13.3.1.app, VM_IMAGE: 'macOS-12'}
-        Xcode 13.2.1: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_13.2.1.app, VM_IMAGE: 'macOS-12'}
-        Xcode 13.1: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_13.1.app, VM_IMAGE: 'macOS-12'}
-        Xcode 13.0: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_13.0.app, VM_IMAGE: 'macOS-11'}
-        Xcode 12.5.1: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_12.5.1.app, VM_IMAGE: 'macOS-11'}
-        Xcode 12.4: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_12.4.app, VM_IMAGE: 'macOS-11'}
-        # Xcode 12.3: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_12.3.app, VM_IMAGE: 'macOS-10.15'}
-        # Xcode 12.2: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_12.2.app, VM_IMAGE: 'macOS-10.15'}
-        # Xcode 12.1.1: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_12.1.1.app, VM_IMAGE: 'macOS-10.15'}
-        # Xcode 12.0.1: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_12.0.1.app, VM_IMAGE: 'macOS-10.15'}
-        Xcode 11.7: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_11.7.app, VM_IMAGE: 'macOS-11'}
-        # Xcode 11.6: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_11.6.app, VM_IMAGE: 'macOS-10.15'}
-        # Xcode 11.5: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_11.5.app, VM_IMAGE: 'macOS-10.15'}
-        # Xcode 11.4.1: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_11.4.1.app, VM_IMAGE: 'macOS-10.15'}
-        # Xcode 11.3.1: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_11.3.1.app, VM_IMAGE: 'macOS-10.15'}
-        # Xcode 11.3: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_11.3.app, VM_IMAGE: 'macOS-10.15'}
-        # Xcode 11.2.1: {TOOLSET: clang, TEST_TOOLSET: clang, CXX: clang++, XCODE_APP: /Applications/Xcode_11.2.1.app, VM_IMAGE: 'macOS-10.15'}
+        # Xcode 13.4.1: {XCODE_APP: /Applications/Xcode_13.4.1.app, VM_IMAGE: 'macOS-12'}
+        Xcode 13.3.1: {XCODE_APP: /Applications/Xcode_13.3.1.app, VM_IMAGE: 'macOS-12'}
+        Xcode 13.2.1: {XCODE_APP: /Applications/Xcode_13.2.1.app, VM_IMAGE: 'macOS-12'}
+        Xcode 13.1: {XCODE_APP: /Applications/Xcode_13.1.app, VM_IMAGE: 'macOS-12'}
+        Xcode 13.0: {XCODE_APP: /Applications/Xcode_13.0.app, VM_IMAGE: 'macOS-11'}
+        Xcode 12.5.1: {XCODE_APP: /Applications/Xcode_12.5.1.app, VM_IMAGE: 'macOS-11'}
+        Xcode 12.4: {XCODE_APP: /Applications/Xcode_12.4.app, VM_IMAGE: 'macOS-11'}
+        # Xcode 12.3: {XCODE_APP: /Applications/Xcode_12.3.app, VM_IMAGE: 'macOS-10.15'}
+        # Xcode 12.2: {XCODE_APP: /Applications/Xcode_12.2.app, VM_IMAGE: 'macOS-10.15'}
+        # Xcode 12.1.1: {XCODE_APP: /Applications/Xcode_12.1.1.app, VM_IMAGE: 'macOS-10.15'}
+        # Xcode 12.0.1: {XCODE_APP: /Applications/Xcode_12.0.1.app, VM_IMAGE: 'macOS-10.15'}
+        Xcode 11.7: {XCODE_APP: /Applications/Xcode_11.7.app, VM_IMAGE: 'macOS-11'}
+        # Xcode 11.6: {XCODE_APP: /Applications/Xcode_11.6.app, VM_IMAGE: 'macOS-10.15'}
+        # Xcode 11.5: {XCODE_APP: /Applications/Xcode_11.5.app, VM_IMAGE: 'macOS-10.15'}
+        # Xcode 11.4.1: {XCODE_APP: /Applications/Xcode_11.4.1.app, VM_IMAGE: 'macOS-10.15'}
+        # Xcode 11.3.1: {XCODE_APP: /Applications/Xcode_11.3.1.app, VM_IMAGE: 'macOS-10.15'}
+        # Xcode 11.3: {XCODE_APP: /Applications/Xcode_11.3.app, VM_IMAGE: 'macOS-10.15'}
+        # Xcode 11.2.1: {XCODE_APP: /Applications/Xcode_11.2.1.app, VM_IMAGE: 'macOS-10.15'}
     pool:
       vmImage: $(VM_IMAGE)
     steps:

--- a/src/engine/execunix.cpp
+++ b/src/engine/execunix.cpp
@@ -461,7 +461,7 @@ void exec_wait()
     while ( !finished )
     {
         int i;
-        int select_timeout = globs.timeout;
+        long select_timeout = globs.timeout;
 
         /* Check for timeouts:
          *   - kill children that already timed out
@@ -474,7 +474,7 @@ void exec_wait()
             for ( i = 0; i < globs.jobs; ++i )
                 if ( cmdtab[ i ].pid )
                 {
-                    clock_t const consumed =
+                    long const consumed = (long)
                         ( current - cmdtab[ i ].start_time ) / tps;
                     if ( consumed >= globs.timeout )
                     {

--- a/test/BoostBuild.py
+++ b/test/BoostBuild.py
@@ -99,7 +99,16 @@ def get_toolset():
     for arg in sys.argv[1:]:
         if not arg.startswith("-"):
             toolset = arg
-    return toolset or "gcc"
+
+    if toolset:
+        return toolset
+
+    if sys.platform == "win32":
+        return "msvc"
+    if sys.platform == "darwin" or sys.platform.startswith("freebsd"):
+        return "clang"
+
+    return "gcc"
 
 
 # Detect the host OS.


### PR DESCRIPTION
Had to change macos scripts because they could not handle versioned toolset (`TOOLSET: gcc-12`) - simplified them like did before to linux. Made clang the default test suite toolset on macos to simplify tests configs even slightly more.