### PR TITLE
gcc: unify mingw linking

### DIFF
--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -36,7 +36,6 @@ toolset.inherit-flags clang-linux : gcc
     <lto>on/<lto-mode>full
     <lto>on/<lto-mode>fat
   : INCLUDE-GCH
-    .IMPLIB-COMMAND
   ;
 
 if [ MATCH (--debug-configuration) : [ modules.peek : ARGV ] ] {

--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -762,14 +762,14 @@ g = [ new gcc-linking-generator gcc.mingw.link
       : OBJ SEARCHED_LIB STATIC_LIB IMPORT_LIB
       : EXE
       : <toolset>gcc <target-os>windows ] ;
-$(g).set-rule-name gcc.link.mingw ;
+$(g).set-rule-name gcc.link ;
 generators.register $(g) ;
 
 g = [ new gcc-linking-generator gcc.mingw.link.dll
       : OBJ SEARCHED_LIB STATIC_LIB IMPORT_LIB
-      : IMPORT_LIB SHARED_LIB
+      : SHARED_LIB IMPORT_LIB
       : <toolset>gcc <target-os>windows ] ;
-$(g).set-rule-name gcc.link.dll.mingw ;
+$(g).set-rule-name gcc.link.dll ;
 generators.register $(g) ;
 
 generators.register
@@ -799,7 +799,7 @@ generators.register $(g) ;
 
 g = [ new gcc-linking-generator gcc.cygwin.link.dll
       : OBJ SEARCHED_LIB STATIC_LIB IMPORT_LIB
-      : IMPORT_LIB SHARED_LIB
+      : SHARED_LIB IMPORT_LIB
       : <toolset>gcc <target-os>cygwin ] ;
 $(g).set-rule-name gcc.link.dll ;
 generators.register $(g) ;
@@ -834,9 +834,6 @@ toolset.flags gcc.link OPTIONS <undefined-sanitizer>on : -fsanitize=undefined -f
 toolset.flags gcc.link OPTIONS <undefined-sanitizer>norecover : -fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer ;
 
 toolset.flags gcc.link OPTIONS <coverage>on : --coverage ;
-
-toolset.flags gcc.link.dll .IMPLIB-COMMAND <target-os>windows : "-Wl,--out-implib," ;
-toolset.flags gcc.link.dll .IMPLIB-COMMAND <target-os>cygwin : "-Wl,--out-implib," ;
 
 # target specific link flags
 {
@@ -1030,26 +1027,6 @@ rule link.dll ( targets * : sources * : properties * )
     quote-rpath $(targets) ;
 }
 
-rule link.mingw ( targets * : sources * : properties * )
-{
-    SPACE on $(targets) = " " ;
-}
-
-rule link.dll.mingw ( targets * : sources * : properties * )
-{
-    SPACE on $(targets) = " " ;
-}
-
-actions link.mingw bind LIBRARIES
-{
-    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" -o "$(<)" @($(<:T).rsp:O=FC:<=@":>=":E=$(START-GROUP) "$(>:T)" "$(LIBRARIES:T)" $(FINDLIBS-ST-PFX:T) -l$(FINDLIBS-ST:T) $(FINDLIBS-SA-PFX:T) -l$(FINDLIBS-SA:T) $(END-GROUP)) $(OPTIONS) $(USER_OPTIONS)
-}
-
-actions link.dll.mingw bind LIBRARIES
-{
-    "$(CONFIG_COMMAND)" -L"$(LINKPATH)" "$(.IMPLIB-COMMAND)$(<[1])" -o "$(<[-1])" -shared @($(<[-1]:T).rsp:O=FC:<=@":>=":E=$(START-GROUP) "$(>:T)" "$(LIBRARIES:T)" $(FINDLIBS-ST-PFX:T) -l$(FINDLIBS-ST:T) $(FINDLIBS-SA-PFX:T) -l$(FINDLIBS-SA:T) $(END-GROUP)) $(OPTIONS) $(USER_OPTIONS)
-}
-
 actions link bind LIBRARIES
 {
     "$(CONFIG_COMMAND)" @($(<[1]:T).rsp:O=FC:<=@":>=":E=-L"$(LINKPATH)" -Wl,$(RPATH_OPTION:E=-R)$(SPACE)-Wl,$(RPATH) -Wl,-rpath-link$(SPACE)-Wl,"$(RPATH_LINK)" -o "$(<)" $(START-GROUP) "$(>:T)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS))
@@ -1057,7 +1034,7 @@ actions link bind LIBRARIES
 
 actions link.dll bind LIBRARIES
 {
-    "$(CONFIG_COMMAND)" @($(<[1]:T).rsp:O=FC:<=@":>=":E=-L"$(LINKPATH)" -Wl,$(RPATH_OPTION:E=-R)$(SPACE)-Wl,$(RPATH) "$(.IMPLIB-COMMAND)$(<[1])" -o "$(<[-1])" $(HAVE_SONAME)-Wl,$(SONAME_OPTION)$(SPACE)-Wl,$(<[-1]:D=) -shared $(START-GROUP) "$(>:T)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS))
+    "$(CONFIG_COMMAND)" @($(<[1]:T).rsp:O=FC:<=@":>=":E=-L"$(LINKPATH)" -Wl,$(RPATH_OPTION:E=-R)$(SPACE)-Wl,$(RPATH) -Wl,$(IMPLIB_OPTION:E=--out-implib),"$(<[2])" -o "$(<[1])" $(HAVE_SONAME)-Wl,$(SONAME_OPTION)$(SPACE)-Wl,$(<[1]:D=) -shared $(START-GROUP) "$(>:T)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS))
 }
 
 ###


### PR DESCRIPTION
Rearranging to `SHARED_LIB IMPORT_LIB` order makes `$(<[2])` always an implib and allows to drive `--out-implib` by generator directly without any chances to produce an implib with the main generator which is not meant to produce them.

Side note: this is a kind of change which would greatly benefit from toolset mock tests if they were presented for non-mainstream toolsets.