### PR TITLE
pdb order issues tentative fix

### DIFF
--- a/src/build/generators.jam
+++ b/src/build/generators.jam
@@ -584,7 +584,18 @@ class generator
                 $(project) : $(a) ] ;
         }
 
+        targets += [ additional-targets-produced $(sources) : $(property-set)
+                   : $(project) $(name) $(a) : $(targets) ] ;
+
         return [ sequence.transform virtual-target.register : $(targets) ] ;
+    }
+
+    # Hook to produce additional targets for cases which could not be (easily)
+    # solved by registering multiple constrained generators.
+    #
+    rule additional-targets-produced ( sources + : property-set
+                                     : project name action : targets + )
+    {
     }
 
     # Attempts to convert 'sources' to targets of types that this generator can

--- a/src/build/virtual-target.jam
+++ b/src/build/virtual-target.jam
@@ -756,12 +756,6 @@ class action
         self.targets += $(targets) ;
     }
 
-    rule replace-targets ( old-targets * : new-targets * )
-    {
-        self.targets = [ set.difference $(self.targets) : $(old-targets) ] ;
-        self.targets += $(new-targets) ;
-    }
-
     rule targets ( )
     {
         return $(self.targets) ;

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1819,17 +1819,10 @@ class msvc-linking-generator : linking-generator
                                      : project name action : targets + )
     {
         local result ;
-        local name-main = [ $(targets[1]).name ] ;
 
         if [ $(property-set).get <debug-symbols> ] = "on"
         {
-            # We force the exact name on PDB. The reason is tagging -- the
-            # tag rule may reasonably special case some target types, like
-            # SHARED_LIB. The tag rule will not catch PDBs, and it cannot
-            # even easily figure out if a PDB is paired with a SHARED_LIB,
-            # EXE or something else. Because PDBs always get the same name
-            # as the main target, with .pdb as extension, just force it.
-            result += [ class.new file-target $(name-main:S=.pdb) exact
+            result += [ class.new file-target $(name)
                 : PDB : $(project) : $(action) ] ;
         }
 
@@ -1839,6 +1832,7 @@ class msvc-linking-generator : linking-generator
             # name of the main target, including extension, e.g.
             # a.exe.manifest. We use the 'exact' name to achieve this
             # effect.
+            local name-main = [ $(targets[1]).name ] ;
             result += [ class.new file-target $(name-main).manifest exact
                 : MANIFEST : $(project) : $(action) ] ;
         }

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1813,56 +1813,36 @@ rule get-rspline ( target : lang-opt lang-flags )
 
 class msvc-linking-generator : linking-generator
 {
-    # Calls the base version.  If necessary, also create a target for the
-    # manifest file.specifying source's name as the name of the created
-    # target. As result, the PCH will be named whatever.hpp.gch, and not
-    # whatever.gch.
-    rule generated-targets ( sources + : property-set : project name ? )
+    # Linking may produce additional targets which needs registration
+    # to be copied by stage (install) step.
+    rule additional-targets-produced ( sources + : property-set
+                                     : project name action : targets + )
     {
-        local result = [ linking-generator.generated-targets $(sources)
-          : $(property-set) : $(project) $(name) ] ;
+        local result ;
+        local name-main = [ $(targets[1]).name ] ;
 
-        if $(result)
+        if [ $(property-set).get <debug-symbols> ] = "on"
         {
-            local name-main = [ $(result[1]).name ] ;
-            local action = [ $(result[1]).action ] ;
-
-            if [ $(property-set).get <debug-symbols> ] = "on"
-            {
-                # We force the exact name on PDB. The reason is tagging -- the
-                # tag rule may reasonably special case some target types, like
-                # SHARED_LIB. The tag rule will not catch PDBs, and it cannot
-                # even easily figure out if a PDB is paired with a SHARED_LIB,
-                # EXE or something else. Because PDBs always get the same name
-                # as the main target, with .pdb as extension, just force it.
-                local target = [ class.new file-target $(name-main:S=.pdb) exact
-                    : PDB : $(project) : $(action) ] ;
-                local registered-target = [ virtual-target.register $(target) ]
-                    ;
-                if $(target) != $(registered-target)
-                {
-                    $(action).replace-targets $(target) : $(registered-target) ;
-                }
-                result += $(registered-target) ;
-            }
-
-            if [ $(property-set).get <embed-manifest> ] = "off"
-            {
-                # Manifest is an evil target. It has .manifest appened to the
-                # name of the main target, including extension, e.g.
-                # a.exe.manifest. We use the 'exact' name to achieve this
-                # effect.
-                local target = [ class.new file-target $(name-main).manifest
-                    exact : MANIFEST : $(project) : $(action) ] ;
-                local registered-target = [ virtual-target.register $(target) ]
-                    ;
-                if $(target) != $(registered-target)
-                {
-                    $(action).replace-targets $(target) : $(registered-target) ;
-                }
-                result += $(registered-target) ;
-            }
+            # We force the exact name on PDB. The reason is tagging -- the
+            # tag rule may reasonably special case some target types, like
+            # SHARED_LIB. The tag rule will not catch PDBs, and it cannot
+            # even easily figure out if a PDB is paired with a SHARED_LIB,
+            # EXE or something else. Because PDBs always get the same name
+            # as the main target, with .pdb as extension, just force it.
+            result += [ class.new file-target $(name-main:S=.pdb) exact
+                : PDB : $(project) : $(action) ] ;
         }
+
+        if [ $(property-set).get <embed-manifest> ] = "off"
+        {
+            # Manifest is an evil target. It has .manifest appened to the
+            # name of the main target, including extension, e.g.
+            # a.exe.manifest. We use the 'exact' name to achieve this
+            # effect.
+            result += [ class.new file-target $(name-main).manifest exact
+                : MANIFEST : $(project) : $(action) ] ;
+        }
+
         return $(result) ;
     }
 }

--- a/test/BoostBuild.py
+++ b/test/BoostBuild.py
@@ -353,6 +353,9 @@ class Tester(TestCmd.TestCmd):
     def is_implib_expected(self):
         return self.target_os in ["windows", "cygwin"] and not self.toolset.startswith("clang-linux")
 
+    def is_pdb_expected(self):
+        return self.toolset == "msvc" or "-win" in self.toolset
+
     #
     # Methods that change the working directory's content.
     #
@@ -568,8 +571,6 @@ class Tester(TestCmd.TestCmd):
                     expected_duration))
                 self.fail_test(1, dump_stdio=False)
 
-        self.__ignore_junk()
-
     def glob_file(self, name):
         name = self.adjust_name(name)
         result = None
@@ -771,6 +772,7 @@ class Tester(TestCmd.TestCmd):
         self.ignore("*.dSYM/*")
 
     def expect_nothing_more(self):
+        self.__ignore_junk()
         if not self.unexpected_difference.empty():
             annotation("failure", "Unexpected changes found")
             output = StringIO()

--- a/test/tag.py
+++ b/test/tag.py
@@ -7,6 +7,8 @@
 
 import BoostBuild
 
+import re
+from functools import reduce
 
 ###############################################################################
 #
@@ -79,24 +81,26 @@ stage c : a ;
 
     t.write("a.cpp", """\
 int main() {}
-#ifdef _MSC_VER
-__declspec (dllexport) void x () {}
-#endif
 """)
 
-    file_list = (
-        BoostBuild.List("bin/$toolset/debug*/a_ds.exe") +
-        BoostBuild.List("bin/$toolset/debug*/b_ds.dll") +
-        BoostBuild.List("c/a_ds.exe") +
-        BoostBuild.List("bin/$toolset/release*/a_rs.exe") +
-        BoostBuild.List("bin/$toolset/release*/b_rs.dll") +
-        BoostBuild.List("c/a_rs.exe") +
-        BoostBuild.List("bin/$toolset/debug*/a_dt.exe") +
-        BoostBuild.List("bin/$toolset/debug*/b_dt.lib") +
-        BoostBuild.List("c/a_dt.exe") +
-        BoostBuild.List("bin/$toolset/release*/a_rt.exe") +
-        BoostBuild.List("bin/$toolset/release*/b_rt.lib") +
-        BoostBuild.List("c/a_rt.exe"))
+    file_list = {
+        "bin/$toolset/debug*/a_ds.exe",
+        "bin/$toolset/debug*/b_ds.dll",
+        "c/a_ds.exe",
+        "bin/$toolset/release*/a_rs.exe",
+        "bin/$toolset/release*/b_rs.dll",
+        "c/a_rs.exe",
+        "bin/$toolset/debug*/a_dt.exe",
+        "bin/$toolset/debug*/b_dt.lib",
+        "c/a_dt.exe",
+        "bin/$toolset/release*/a_rt.exe",
+        "bin/$toolset/release*/b_rt.lib",
+        "c/a_rt.exe",
+    }
+    if t.is_pdb_expected():
+        file_list |= {re.sub(r'(_\w*d\w*)\.(exe|dll)$', r'\1.pdb', file)
+                      for file in file_list}
+    file_list = list(reduce(lambda x, y: x+y, map(BoostBuild.List, file_list)))
 
     variants = ["debug", "release", "link=static,shared"]
 


### PR DESCRIPTION
I believe this is the root cause of mysterious bugs involving pdbs:
  1. `replace-targets` may rearrange targets order, which might be the cause of
     exe/dll/lib swapping places.
  2. The hack in `msvc-linking-generator` were messing things up somehow when
     `virtual-target.register` returns a cached target.

Even if the change does not fix these issues it is still a good code refactor.

Tentatively fixes #177 and https://github.com/boostorg/build/issues/506