### PR TITLE
Fix generator custom rule name inheritance

### DIFF
--- a/src/build/toolset.jam
+++ b/src/build/toolset.jam
@@ -572,8 +572,15 @@ rule inherit-generators ( toolset properties * : base : generators-to-ignore * )
                 base = $(base:B) ;
             }
             local new-id = $(toolset)$(suffix) ;
+            local rule-name = [ $(g).rule-name ] ;
 
-            generators.register [ $(g).clone $(new-id) : $(properties) ] ;
+            g = [ $(g).clone $(new-id) : $(properties) ] ;
+            # Custom rule names needs special handling
+            if $(id) != $(rule-name) {
+                $(g).set-rule-name [ regex.replace $(rule-name) ^$(base)\\. $(toolset). ] ;
+            }
+
+            generators.register $(g) ;
         }
     }
     generators.inherit-overrides $(toolset) : $(base) : $(generators-to-ignore) ;


### PR DESCRIPTION
One example of this is gcc.cygwin/mingw.link which sets rule name to gcc.link. If you let clang-linux inherit such generator -- clone would just reset the name to new-id and execution will fail with attempt to call non-existing clang-linux.cygwin/mingw.link rule.