### PR TITLE
Fix testing.execute=off. Fixes #195

### DIFF
--- a/src/build/targets.jam
+++ b/src/build/targets.jam
@@ -1406,6 +1406,12 @@ class basic-target : abstract-target
                     local result = [ construct $(self.name) : $(source-targets) :
                         $(rproperties) ] ;
 
+                    if $(result) && [ $(result[1]).get <build> ] = no
+                    {
+                        result = ;
+                        skip = true ;
+                    }
+
                     if $(result)
                     {
                         local gur = $(result[1]) ;

--- a/src/tools/testing.jam
+++ b/src/tools/testing.jam
@@ -348,6 +348,28 @@ local rule register-fail-expected ( source-type : test-type )
         testing.expect-failure : $(source-type) : $(test-type) ] ;
 }
 
+class capture-output-generator : generator
+{
+    import generators ;
+
+    rule run ( project name ? : property-set : sources + )
+    {
+        local result = [ generator.run $(project) $(name) : $(property-set)
+            : $(sources) ] ;
+
+        if $(result) && [ $(property-set).get <testing.execute> ] = off
+        {
+            # skip self and dependants but still build dependencies
+            local action = [ $(result[2]).action ] ;
+            local exe = [ $(action).sources ] ;
+            DEPENDS all : [ $(exe).actualize ] ;
+            return [ property-set.create <build>no ] $(result[2-]) ;
+        }
+
+        return $(result) ;
+    }
+}
+
 # Register generators. Depending on target type, either 'expect-success' or
 # 'expect-failure' rule will be used.
 generators.register-standard testing.expect-success : OBJ        : COMPILE      ;
@@ -358,7 +380,7 @@ generators.register-standard testing.expect-success : EXE        : LINK         
 register-fail-expected                                EXE        : LINK_FAIL    ;
 
 # Generator which runs an EXE and captures output.
-generators.register-standard testing.capture-output : EXE : RUN_OUTPUT ;
+generators.register [ class.new capture-output-generator testing.capture-output : EXE : RUN_OUTPUT ] ;
 
 # Generator which creates a target if sources run successfully. Differs from RUN
 # in that run output is not captured. The reason why it exists is that the 'run'
@@ -525,12 +547,6 @@ rule capture-output ( target : source : properties * )
 
     run-path-setup $(target) : $(source) : $(properties) ;
 
-    DISABLE_TEST_EXECUTION on $(target) = 0 ;
-    if [ feature.get-values testing.execute : $(properties) ] = off
-    {
-        DISABLE_TEST_EXECUTION on $(target) = 1 ;
-    }
-
     if ! [ feature.get-values testing.launcher : $(properties) ]
     {
         ## On VMS set default launcher to MCR
@@ -640,11 +656,6 @@ if --verbose-test in [ modules.peek : ARGV ]
 actions capture-output bind INPUT_FILES output-file
 {
     $(PATH_SETUP)
-    $(.SHELL_SET)status=$(DISABLE_TEST_EXECUTION)
-    if $(.STATUS_NOT_0)
-        echo Skipping test execution due to testing.execute=off
-        exit $(.EXIT_SUCCESS)
-    $(.ENDIF)
     $(LAUNCHER) "$(>)" $(ARGS) "$(INPUT_FILES)" > "$(output-file)" 2>&1 $(.NULLIN)
     $(.SET_STATUS)
     $(.RUN_OUTPUT_NL) >> "$(output-file)"
@@ -675,11 +686,6 @@ if [ os.name ] = VMS
     actions capture-output bind INPUT_FILES output-file
     {
         $(PATH_SETUP)
-        $(.SHELL_SET)status=$(DISABLE_TEST_EXECUTION)
-        if $(.STATUS_NOT_0)
-            $(.SAY) "Skipping test execution due to testing.execute=off"
-            exit "$(.EXIT_SUCCESS)"
-        $(.ENDIF)
         !! Execute twice - first for status, second for output
         set noon
         pipe $(LAUNCHER) $(>:W) $(ARGS) $(INPUT_FILES:W) 2>NL: >NL:

--- a/test/testing.py
+++ b/test/testing.py
@@ -82,6 +82,62 @@ run-fail fail-run.cpp ;
 
     t.cleanup()
 
+
+def test_run_execute_off():
+    t = BoostBuild.Tester(use_test_config=False)
+
+    t.write("pass.cpp", "int main() {}\n")
+    t.write("fail-run.cpp", "int main() { return 1; }\n")
+    t.write("Jamroot.jam", """\
+import testing ;
+import notfile ;
+
+rule check ( target : source : properties * )
+{
+    ECHO executed $(target:G=) $(source:G=) ;
+}
+
+run pass.cpp ;
+run-fail fail-run.cpp ;
+notfile a : @check : pass ;
+notfile b : @check : fail-run ;
+""")
+
+    t.run_build_system(["testing.execute=off"])
+    t.expect_addition([
+        "bin/pass.test/$toolset/debug*/pass.obj",
+        "bin/pass.test/$toolset/debug*/pass.exe",
+        "bin/fail-run.test/$toolset/debug*/fail-run.obj",
+        "bin/fail-run.test/$toolset/debug*/fail-run.exe",
+    ])
+    t.fail_test("executed" in t.stdout())
+    t.expect_nothing_more()
+
+    t.run_build_system()
+    t.expect_addition([
+        "bin/pass.test/$toolset/debug*/pass.output",
+        "bin/pass.test/$toolset/debug*/pass.run",
+        "bin/pass.test/$toolset/debug*/pass.test",
+        "bin/fail-run.test/$toolset/debug*/fail-run.output",
+        "bin/fail-run.test/$toolset/debug*/fail-run.run",
+        "bin/fail-run.test/$toolset/debug*/fail-run.test",
+    ])
+    t.expect_output_lines([
+        "executed a pass.test",
+        "executed b fail-run.test",
+    ])
+    t.expect_nothing_more()
+
+    t.run_build_system()
+    t.expect_nothing_more()
+
+    t.run_build_system(["testing.execute=off"])
+    t.fail_test("executed" in t.stdout())
+    t.expect_nothing_more()
+
+    t.cleanup()
+
+
 def test_run_change():
     """Tests that the test file is removed when a test fails after it
     previously passed."""
@@ -541,6 +597,7 @@ testing.compile-fail "invalid source.cpp" ;
 
 test_run()
 test_run_fail()
+test_run_execute_off()
 test_run_change()
 test_run_path()
 test_run_args()


### PR DESCRIPTION
1. run-fail tests were failing with testing.execute=off
2. rerun w/o testing.execute=off did nothing

UPD: Found a better solution.
