### PR TITLE
MSYS2 fixes and CI

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -1,0 +1,71 @@
+# Copyright 2023 Nikita Kniazev
+#
+# Use, modification, and distribution are subject to the
+# Boost Software License, Version 1.0. (See accompanying file LICENSE.txt)
+
+name: "Extra Tests"
+
+on:
+  push:
+    paths-ignore: #&paths
+      - '.circleci/**'
+      - '.cirrus.yml'
+      - '.drone.star'
+      - '.semaphore/**'
+      - '.travis.yml'
+      - 'appveyor.yml'
+      - 'azure-pipelines.yml'
+      - '.ci/azp-*.yml'
+  pull_request:
+    paths-ignore: #*paths #https://github.com/actions/runner/issues/1182
+      - '.circleci/**'
+      - '.cirrus.yml'
+      - '.drone.star'
+      - '.semaphore/**'
+      - '.travis.yml'
+      - 'appveyor.yml'
+      - 'azure-pipelines.yml'
+      - '.ci/azp-*.yml'
+
+concurrency:
+  # cancel test runners on force-push in pull requests
+  group: ${{ github.event_name == 'push' && github.event.forced && github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  msys2:
+    name: Windows msys2 ${{matrix.msys}} ${{matrix.toolset}}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        msys:
+          - mingw64
+          - mingw32
+          - ucrt64
+          - clang64
+        toolset:
+          - clang
+          - gcc
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Install Toolset
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.msys}}
+          pacboy: python:p ${{matrix.toolset}}:p
+
+      - name: Bootstrap
+        run: ./bootstrap.sh ${{matrix.toolset}}
+
+      - name: Test
+        working-directory: test
+        run: ./test_all.py ${{matrix.toolset}}
+
+      - name: 'No Warnings'
+        run: ./b2 warnings=all warnings-as-errors=on variant=debug,release debug-symbols=off toolset=${{matrix.toolset}} b2

--- a/test/builtin_glob.py
+++ b/test/builtin_glob.py
@@ -14,14 +14,12 @@ def test_glob(files, glob, expected, setup=""):
     t.write("file.jam", setup + """
     for local p in [ SORT %s ]
     {
-        ECHO $(p) ;
+        ECHO $(p:T) ;
     }
     UPDATE ;
     """ % glob)
     for f in files:
         t.write(f, "")
-    # convert / into \ on windows
-    expected = [os.path.join(*p.split("/")) for p in expected]
     expected.sort()
     t.run_build_system(stdout="\n".join(expected + [""]))
     t.cleanup()

--- a/test/core_bindrule.py
+++ b/test/core_bindrule.py
@@ -30,7 +30,7 @@ BINDRULE = bind-rule ;
 
 rule bind-rule ( target : path )
 {
-    ECHO "found:" $(target) at $(path) ;
+    ECHO "found:" $(target) at $(path:T) ;
 }
 
 DEPENDS all : fake-target ;
@@ -38,8 +38,8 @@ DEPENDS all : fake-target ;
 
 t.run_build_system(["-ffile.jam"], stdout="""\
 found: all at all
-found: file-to-bind at subdir1%sfile-to-bind
+found: file-to-bind at subdir1/file-to-bind
 ...found 3 targets...
-""" % os.sep)
+""")
 
 t.cleanup()

--- a/test/prebuilt.py
+++ b/test/prebuilt.py
@@ -21,12 +21,13 @@ t.run_build_system(subdir="ext")
 # Then pretend that we do not have the sources for the external project, and
 # can only use compiled binaries.
 t.copy("ext/jamfile2.jam", "ext/jamfile.jam")
-t.expand_toolset("ext/jamfile.jam")
+
+libname = t.adjust_name("a.implib" if t.is_implib_expected() else "a.dll") 
 
 # Now check that we can build the main project, and that correct prebuilt file
 # is picked, depending of variant. This also checks that correct includes for
 # prebuilt libraries are used.
-t.run_build_system()
+t.run_build_system([f"-sLIBNAME={libname}"])
 t.expect_addition("bin/$toolset/debug*/hello.exe")
 t.expect_addition("bin/$toolset/release*/hello.exe")
 
@@ -35,8 +36,7 @@ t.rm("bin")
 
 # Now test that prebuilt file specified by absolute name works too.
 t.copy("ext/jamfile3.jam", "ext/jamfile.jam")
-t.expand_toolset("ext/jamfile.jam")
-t.run_build_system()
+t.run_build_system([f"-sLIBNAME={libname}"])
 t.expect_addition("bin/$toolset/debug*/hello.exe")
 t.expect_addition("bin/$toolset/release*/hello.exe")
 

--- a/test/prebuilt/ext/jamfile2.jam
+++ b/test/prebuilt/ext/jamfile2.jam
@@ -1,40 +1,16 @@
-
-import os ;
-
-local dll-suffix = so ;
-local prefix = "lib" ;
-if [ os.name ] in NT
-{
-   if [ MATCH ^(gcc) : $toolset ]
-   {
-      dll-suffix = dll.a ;
-      prefix = lib ;
-   }
-   else
-   {
-      dll-suffix = lib ;
-      prefix = "" ;
-   }
-}
-else if [ os.name ] in CYGWIN
-{
-    dll-suffix = dll.a ;
-}
-else if [ os.name ] in MACOSX
-{
-   dll-suffix = dylib ;
-}
+import modules ;
+LIBNAME = [ modules.peek : LIBNAME ] ;
 
 project ext ;
 
 lib a :
-    : <file>debug/$(prefix)a.$(dll-suffix) <variant>debug
+    : <file>debug/$(LIBNAME:E=LIBNAME-not-defined) <variant>debug
     :
     : <include>debug
     ;
 
 lib a :
-    : <file>release/$(prefix)a.$(dll-suffix) <variant>release
+    : <file>release/$(LIBNAME:E=LIBNAME-not-defined) <variant>release
     :
     : <include>release
     ;

--- a/test/prebuilt/ext/jamfile3.jam
+++ b/test/prebuilt/ext/jamfile3.jam
@@ -3,31 +3,8 @@
 # it tries to access prebuilt targets using absolute
 # paths. It used to be broken on Windows.
 
-import os ;
-
-local dll-suffix = so ;
-local prefix = "lib" ;
-if [ os.name ] in NT
-{
-   if [ MATCH ^(gcc) : $toolset ]
-   {
-      dll-suffix = dll.a ;
-      prefix = lib ;
-   }
-   else
-   {
-      dll-suffix = lib ;
-      prefix = "" ;
-   }
-}
-else if [ os.name ] in CYGWIN
-{
-    dll-suffix = dll.a ;
-}
-else if [ os.name ] in MACOSX
-{
-   dll-suffix = dylib ;
-}
+import modules ;
+LIBNAME = [ modules.peek : LIBNAME ] ;
 
 project ext ;
 
@@ -35,13 +12,13 @@ project ext ;
 local pwd = [ PWD ] ;
 
 lib a :
-    : <file>$(pwd)/ext/debug/$(prefix)a.$(dll-suffix) <variant>debug
+    : <file>$(pwd)/ext/debug/$(LIBNAME:E=LIBNAME-not-defined) <variant>debug
     :
     : <include>debug
     ;
 
 lib a :
-    : <file>$(pwd)/ext/release/$(prefix)a.$(dll-suffix) <variant>release
+    : <file>$(pwd)/ext/release/$(LIBNAME:E=LIBNAME-not-defined) <variant>release
     :
     : <include>release
     ;

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -48,7 +48,9 @@ def run_test(test):
         __import__(test)
     except BaseException as e:
         exc = e
-    return test, time.perf_counter() - ts, exc, BoostBuild.annotations
+    annotations = BoostBuild.annotations.copy()
+    BoostBuild.annotations.clear()
+    return test, time.perf_counter() - ts, exc, annotations
 
 
 def run_tests(critical_tests, other_tests):


### PR DESCRIPTION
I've setup CI on GHA because it is much more convenient using their action script.

This covers different Mingw setups and it does not fail on PCH tests like Mingw-w64 one installed by default on GHA/Azure (either because GCC exe there built without ASLR or GCC there is a new one which supports PCH relocation).
