### PR TITLE
sequence.unique massive performance boost

### DIFF
--- a/src/build/configure.jam
+++ b/src/build/configure.jam
@@ -176,7 +176,7 @@ rule maybe-force-rebuild ( targets * )
         {
             all-targets += [ virtual-target.traverse $(t) ] ;
         }
-        for local t in [ sequence.unique $(all-targets) ]
+        for local t in $(all-targets)
         {
             $(t).always ;
         }

--- a/src/build/feature.jam
+++ b/src/build/feature.jam
@@ -1316,16 +1316,16 @@ rule __test__ ( )
 
     assert.result optional : attributes <fu> ;
 
-    assert.result [ SORT <define>_DEBUG <runtime-link>static
+    assert.result-set-equal <define>_DEBUG <runtime-link>static
         <define>foobar <optimization>on
         <toolset>gcc <variant>debug <stdlib>native
-        <dummy>dummy1 <toolset-gcc:version>2.95.2 ]
+        <dummy>dummy1 <toolset-gcc:version>2.95.2
         : add-defaults <runtime-link>static <define>foobar <optimization>on ;
 
-    assert.result [ SORT <define>_DEBUG <runtime-link>static
+    assert.result-set-equal <define>_DEBUG <runtime-link>static
         <define>foobar <optimization>on
         <fu>fu1 <toolset>gcc <variant>debug
-        <stdlib>native <dummy>dummy1 <fu-subfu2>q <toolset-gcc:version>2.95.2 ]
+        <stdlib>native <dummy>dummy1 <fu-subfu2>q <toolset-gcc:version>2.95.2
         : add-defaults <runtime-link>static <define>foobar <optimization>on
           <fu>fu1 ;
 

--- a/src/build/targets.jam
+++ b/src/build/targets.jam
@@ -275,7 +275,7 @@ class project-target : abstract-target
             targets += $(g[2-]) ;
         }
         targets.decrease-indent ;
-        return $(usage-requirements) [ sequence.unique $(targets) ] ;
+        return $(usage-requirements) [ sequence.unique $(targets) : stable ] ;
     }
 
     # Computes and returns a list of abstract-target instances which must be
@@ -809,7 +809,7 @@ class main-target : abstract-target
             }
         }
         end-building $(__name__) ;
-        return $(usage-requirements) [ sequence.unique $(result) ] ;
+        return $(usage-requirements) [ sequence.unique $(result) : stable ] ;
     }
 
     # Generates the main target with the given property set and returns a list

--- a/src/engine/lists.h
+++ b/src/engine/lists.h
@@ -259,6 +259,14 @@ struct list_cref::iterator
 	{
 		return list_i - b.list_i;
 	}
+	inline iterator operator+(difference_type count) const
+	{
+		return iterator(list_i + count);
+	}
+	inline iterator operator-(difference_type count) const
+	{
+		return iterator(list_i - count);
+	}
 
 	private:
 	LISTITER list_i;

--- a/src/util/sequence.jam
+++ b/src/util/sequence.jam
@@ -218,33 +218,10 @@ rule length ( s * )
 # Removes duplicates from 'list'.  If 'stable' is
 # passed, then the order of the elements will
 # be unchanged.
-rule unique ( list * : stable ? )
-{
-    local result ;
-    local prev ;
-    if $(stable)
-    {
-        for local f in $(list)
-        {
-            if ! $(f) in $(result)
-            {
-                result += $(f) ;
-            }
-        }
-    }
-    else
-    {
-        for local i in [ SORT $(list) ]
-        {
-            if $(i) != $(prev)
-            {
-                result += $(i) ;
-            }
-            prev = $(i) ;
-        }
-    }
-    return $(result) ;
-}
+#
+# rule unique ( list * : stable ? )
+
+NATIVE_RULE sequence : unique ;
 
 
 # Returns the maximum number in 'elements'. Uses 'ordered' for comparisons or
@@ -367,7 +344,9 @@ rule __test__ ( )
         }
         assert.result 256 : sequence.length $(p2) ;
 
-        assert.result 1 2 3 4 5 : sequence.unique 1 2 3 2 4 3 3 5 5 5 ;
+        assert.result-set-equal 1 2 3 4 5 : sequence.unique 1 2 3 2 4 3 3 5 5 5 ;
+
+        assert.result 1 4 3 2 5 : sequence.unique 1 4 4 3 2 4 3 3 5 5 5 : stable ;
 
         assert.result 5 : sequence.max-element 1 3 5 0 4 ;
 


### PR DESCRIPTION
Boost@develop `b2 --layout=versioned -n install -d+10`
build | was    now    |     sequence.unique
--- | --- | ---
clean | 594 -> 230 (2.6x) |  366 -> 1.29 (284x)
rerun |547 -> 182 (3.0x)  | 362 -> 1.27 (285x)

I've changed unification in generators to be stable because it is faster somehow (by 33% vs non-sorting non-stable unique, by 180% vs sorting unique), plus it is preferable that targets are built in the order of declaration.
