### PR TITLE
`virtual-target.register` 6x performance improvement

### DIFF
--- a/src/build/virtual-target.jam
+++ b/src/build/virtual-target.jam
@@ -994,47 +994,17 @@ rule from-file ( file : file-loc : project )
 #
 rule register ( target )
 {
-    local signature = [ sequence.join [ $(target).path ] [ $(target).name ] : -
-        ] ;
-
-    local result ;
-    for local t in $(.cache.$(signature))
-    {
-        local a1 = [ $(t).action ] ;
-        local a2 = [ $(target).action ] ;
-
-        if ! $(result)
-        {
-            if ! $(a1) && ! $(a2)
-            {
-                result = $(t) ;
-            }
-            else if $(a1) && $(a2) &&
-                ( [ $(a1).action-name ] = [ $(a2).action-name ] ) &&
-                ( [ $(a1).sources     ] = [ $(a2).sources     ] )
-            {
-                local ps1 = [ $(a1).properties ] ;
-                local ps2 = [ $(a2).properties ] ;
-                local relevant = [ toolset.relevant [ $(a1).action-name ] ] ;
-                relevant = [ $(relevant).add [ $(target).relevant ] ] ;
-                local p1 = [ $(ps1).relevant $(relevant) ] ;
-                local p2 = [ $(ps2).relevant $(relevant) ] ;
-                if $(p1) = $(p2)
-                {
-                    result = $(t) ;
-                }
-            }
-        }
-    }
+    local signature = [ $(target).actual-name ] ;
+    local result = $(.cache.$(signature)) ;
 
     if ! $(result)
     {
         .cache.$(signature) += $(target) ;
+        .all-targets += $(target) ;
         result = $(target) ;
     }
 
     .recent-targets += $(result) ;
-    .all-targets += $(result) ;
 
     return $(result) ;
 }


### PR DESCRIPTION
total 79.2 -> 13.2 (6.0x)
self 34.2 -> 8.1 (4.2x)

`target.actual-name` is an ideal cache key because it is already used to register targets in the build engine which requires on it to be unique enough to not collide, while also is the shortest unique identifying string which is for a file targets consists of the target relevant properties, path prefix and name.

This simplification also makes it easy to port `register/recent-targets/clear-recent-targets/all-targets` to native which probably will have a significant impact too (at least on these 8 seconds `virtual-target.register` self time).