### PR TITLE
Fix msvc auto config version priority.

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1075,6 +1075,10 @@ local rule auto-detect-toolset-versions ( )
                     register-configuration $(i) : [ path.native $(vc-path[1]) ] ;
                 }
             }
+            else
+            {
+                register-configuration $(i) : [ default-path $(i) ] ;
+            }
         }
     }
 


### PR DESCRIPTION
## Proposed changes

When configuring all msvc toolsets we would configure the ones from the registry followed by known location versions. This had the effect of making msvc versions from the registry the default over the pathed ones. Since the newer releases, after 14.0, don't use the registry it meant that even if you had new ones it would pick 14.0 (or earlier) as the default. This change tries to register them with registry and pathed each. Which results in preserving the new-to-old ordering. Resulting in the newest being the default, as intended.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [x] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
