### PR TITLE
Fix use-project with native paths.

### DIFF
--- a/src/build/project.jam
+++ b/src/build/project.jam
@@ -1266,8 +1266,9 @@ module project-rules
         import path ;
         local caller = [ CALLER_MODULE ] ;
         local location = [ project.attribute $(caller) location ] ;
-        modules.poke $(caller) : .used-projects : [ modules.peek $(caller) :
-            .used-projects ] $(id) [ path.root $(where) $(location) ] ;
+        where = [ path.root [ path.make $(where) ] $(location) ] ;
+        modules.poke $(caller) : .used-projects
+            : [ modules.peek $(caller) : .used-projects ] $(id) $(where) ;
     }
 
     rule build-project ( dir )


### PR DESCRIPTION
## Proposed changes

It's possible, and common in Boost, to register projects using native paths (usually from env vars). That would cause incorrect tracking of the projects and result in failing to find them. This change converts the native path to a b2 path for registration. Which resolves finding them when it comes to loading the used projects.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [x] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [x] I added necessary documentation (if appropriate)
