### PR TITLE
Use env variables instead of hardcoded paths for ms-mpi search

### DIFF
--- a/src/tools/mpi.jam
+++ b/src/tools/mpi.jam
@@ -246,35 +246,60 @@ rule init ( mpicxx ? : options * : mpirun-with-options * )
   if ! $(mpicxx) && [ os.on-windows ]
   {
     # Paths for Microsoft MPI
-    local ms_mpi_path_native = "C:\\Program Files\\Microsoft MPI" ;
-    local ms_mpi_sdk_path_native = "C:\\Program Files (x86)\\Microsoft SDKs\\MPI" ;
+    # Treat them explicitly as native OS path references
+    local ms_mpi_bin_native = [ os.environ MSMPI_BIN ] ;
+    if $(ms_mpi_bin_native)
+    {
+      ms_mpi_bin_native = [ path.make $(ms_mpi_bin_native) ] ;
+      ms_mpi_bin_native = [ path.native $(ms_mpi_bin_native) ] ;
+    }
+
+    local ms_mpi_inc_native = [ os.environ MSMPI_INC ] ;
+    if $(ms_mpi_inc_native)
+    {
+      ms_mpi_inc_native = [ path.make $(ms_mpi_inc_native) ] ;
+      ms_mpi_inc_native = [ path.native $(ms_mpi_inc_native) ] ;
+    }
 
     # Path for Microsoft Compute Cluster Pack
     local cluster_pack_path_native = "C:\\Program Files\\Microsoft Compute Cluster Pack" ;
 
     # Try to auto-configure Microsoft MPI
-    if [ GLOB $(ms_mpi_path_native)\\Bin : mpiexec.exe ] &&
-        [ GLOB $(ms_mpi_sdk_path_native)\\Include : mpi.h ]
+    if $(ms_mpi_bin_native) &&
+        $(ms_mpi_inc_native) &&
+        [ GLOB $(ms_mpi_bin_native) : mpiexec.exe ] &&
+        [ GLOB $(ms_mpi_inc_native) : mpi.h ]
     {
       if $(.debug-configuration)
       {
-        ECHO "Found Microsoft MPI: $(ms_mpi_path_native)" ;
-        ECHO "Found Microsoft MPI SDK: $(ms_mpi_sdk_path_native)" ;
+        ECHO "Found Microsoft MPI and Microsoft MPI SDK" ;
       }
 
-      local ms_mpi_sdk_path = [ path.make $(ms_mpi_sdk_path_native) ] ;
+      local ms_mpi_lib32 = [ os.environ MSMPI_LIB32 ] ;
+      if $(ms_mpi_lib32)
+      {
+        ms_mpi_lib32 = [ path.make $(ms_mpi_lib32) ] ;
+      }
+
+      local ms_mpi_lib64 = [ os.environ MSMPI_LIB64 ] ;
+      if $(ms_mpi_lib64)
+      {
+        ms_mpi_lib64 = [ path.make $(ms_mpi_lib64) ] ;
+      }
+
+      local ms_mpi_inc = [ path.make $(ms_mpi_inc_native) ] ;
 
       # Pick up either the 32-bit or 64-bit library, depending on which address
       # model the user has selected. Default to 32-bit.
-      options = <include>$(ms_mpi_sdk_path)/Include
-                <address-model>64:<library-path>$(ms_mpi_sdk_path)/Lib/x64
-                <library-path>$(ms_mpi_sdk_path)/Lib/x86
+      options = <include>$(ms_mpi_inc)
+                <address-model>64:<library-path>$(ms_mpi_lib64)
+                <library-path>$(ms_mpi_lib32)
                 <find-static-library>msmpi
                 <toolset>msvc:<define>_SECURE_SCL=0
               ;
 
       # Setup the "mpirun" equivalent (mpiexec)
-      .mpirun = "\"$(ms_mpi_path_native)\\Bin\\mpiexec.exe"\" ;
+      .mpirun = "\"$(ms_mpi_bin_native)\\mpiexec.exe"\" ;
       .mpirun_flags = -n ;
     }
     # Try to auto-configure to the Microsoft Compute Cluster Pack
@@ -302,8 +327,7 @@ rule init ( mpicxx ? : options * : mpirun-with-options * )
     }
     else if $(.debug-configuration)
     {
-      ECHO "Did not find Microsoft MPI in $(ms_mpi_path_native)" ;
-      ECHO "      and/or Microsoft MPI SDK in $(ms_mpi_sdk_path_native)." ;
+      ECHO "Did not find Microsoft MPI and/or Microsoft MPI SDK" ;
       ECHO "Did not find Microsoft Compute Cluster Pack in $(cluster_pack_path_native)." ;
     }
   }


### PR DESCRIPTION
## Proposed changes

Microsoft MPI Redist and SDK installers set environment variables (`MSMPI_BIN`, `MSMPI_INC`, `MSMPI_LIB32`, `MSMPI_LIB64`) that [described in the example in Microsoft MPI repository](https://github.com/microsoft/Microsoft-MPI/blob/master/examples/helloworld/Run_MPIHelloWorld.md). These environment variables are widely used. For example, CMake uses them in it's FindMPI module [there](https://github.com/Kitware/CMake/blob/07ac0c0ae0bcd7231b6c834303531c313af28090/Modules/FindMPI.cmake#L918) and [there](https://github.com/Kitware/CMake/blob/07ac0c0ae0bcd7231b6c834303531c313af28090/Modules/FindMPI.cmake#L1020), Meson [also uses these variables](https://github.com/mesonbuild/meson/blob/9eb7fe332f6a6a8babd040b76ad2a6808faf0423/mesonbuild/dependencies/mpi.py#L223) to locate MS-MPI. 

This PR changes the way MS-MPI is searched. Instead of hardcoded paths to MS-MPI Redist and SDK, paths from environment variables mentioned above are used. This allows to use MS-MPI Redist and SDK installed to custom path.

I tested these changes with the latest MS-MPI Redist and SDK installed to the default path and to custom path.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)
