### PR TITLE
Fix monospace render problem in tutorial

### DIFF
--- a/doc/src/tutorial.adoc
+++ b/doc/src/tutorial.adoc
@@ -426,7 +426,7 @@ exe app : app.cpp core ;
 This works no matter what kind of linking is used. When `core` is built as a
 shared library, links `utils` directly into it. Static libraries can't link
 to other libraries, so when `core` is built as a static library, its
-dependency on `utils` is passed along to `core`'s dependents, causing `app`
+dependency on `utils` is passed along to ``core``'s dependents, causing `app`
 to be linked with both `core` and `utils`.
 ====
 
@@ -515,7 +515,7 @@ exe app : app.cpp ../util/lib2//lib2 ;
 ----
 
 As with any target, the alternative selected depends on the properties
-propagated from `lib2`'s dependents. If we build the release and debug
+propagated from ``lib2``'s dependents. If we build the release and debug
 versions of `app` it will be linked with `lib2_release.a` and
 `lib2_debug.a`, respectively.
 


### PR DESCRIPTION
According to [documentation](https://docs.asciidoctor.org/asciidoc/latest/text/monospace/) of AsciiDoc:
As with other types of text formatting, if the text is bounded by word characters on either side, it must be enclosed in a double pair of backtick characters (``) in order for the formatting to be applied.

<img width="827" alt="image" src="https://github.com/bfgroup/b2/assets/46747123/195ec136-7981-4ee4-ac2b-14f2549362d4">


## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
