### PR TITLE
Make C/C++/ObjC include directive scanning pattern more strict

### DIFF
--- a/src/tools/types/cpp.jam
+++ b/src/tools/types/cpp.jam
@@ -30,7 +30,7 @@ class c-scanner : scanner
 
     rule pattern ( )
     {
-        return "#[ \t]*include[ \t]*(<(.*)>|\"(.*)\")" ;
+        return "^[ \t]*#[ \t]*include[ \t]*(<(.+)>|\"(.+)\")" ;
     }
 
     rule process ( target : matches * : binding )

--- a/src/tools/types/objc.jam
+++ b/src/tools/types/objc.jam
@@ -14,7 +14,7 @@ class objc-scanner : c-scanner
 
     rule pattern ( )
     {
-        return "#[ \t]*include|import[ ]*(<(.*)>|\"(.*)\")" ;
+        return "^[ \t]*#[ \t]*include|import[ ]*(<(.+)>|\"(.+)\")" ;
     }
 }
 


### PR DESCRIPTION
## Proposed changes

1. Require that the directive is at the beginning of a line, sans leading spaces.
2. Require that the header name is not empty.
    
This eliminates majority of comments that look like `#include` directives. One practical example is [a comment in Boost.Wave](https://github.com/boostorg/wave/blob/737c1e07eedda7f0131ec601df1a34300a1f38f0/include/boost/wave/cpp_iteration_context.hpp#L101-L102) that has `#include <>` and `#include ""` in its body.

This issue came up during Boost 1.85 release preparation.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [ ] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)
