### PR TITLE
Fix QCC debug build flag

### DIFF
--- a/src/tools/qcc.jam
+++ b/src/tools/qcc.jam
@@ -88,7 +88,7 @@ local rule check-target-platform
 }
 
 # Declare flags for compilation.
-toolset.flags qcc.compile OPTIONS <debug-symbols>on : -gstabs+ ;
+toolset.flags qcc.compile OPTIONS <debug-symbols>on : -g ;
 
 # Declare flags and action for compilation.
 toolset.flags qcc.compile OPTIONS <optimization>off : -O0 ;
@@ -215,7 +215,7 @@ generators.register [ new qcc-linking-generator qcc.link.dll : LIB OBJ
 
 # Declare flags for linking.
 # First, the common flags.
-toolset.flags qcc.link OPTIONS <debug-symbols>on : -gstabs+ ;
+toolset.flags qcc.link OPTIONS <debug-symbols>on : -g ;
 toolset.flags qcc.link OPTIONS <profiling>on : -p ;
 toolset.flags qcc.link OPTIONS <linkflags> ;
 toolset.flags qcc.link LINKPATH <library-path> ;


### PR DESCRIPTION
## Proposed changes

This change allows Boost to be built with q++ 7.1. Full details can be found in [this boost issue](https://github.com/boostorg/build/issues/453). It essentially reimplements the patch provided by @Johnnyxy. 

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments
