### PR TITLE
Fix Solaris/SunOS detection

### DIFF
--- a/src/engine/jam.h
+++ b/src/engine/jam.h
@@ -300,14 +300,12 @@
     #define OSMINOR "OS=SINIX"
     #define OS_SINIX
 #endif
-#ifdef sun
-    #if defined(__svr4__) || defined(__SVR4)
-        #define OSMINOR "OS=SOLARIS"
-        #define OS_SOLARIS
-    #else
-        #define OSMINOR "OS=SUNOS"
-        #define OS_SUNOS
-    #endif
+#if defined(__svr4__) || defined(__SVR4)
+    #define OSMINOR "OS=SOLARIS"
+    #define OS_SOLARIS
+#elif defined(__sun__) || defined(__sun) || defined(sun)
+    #define OSMINOR "OS=SUNOS"
+    #define OS_SUNOS
 #endif
 #ifdef ultrix
     #define OSMINOR "OS=ULTRIX"


### PR DESCRIPTION
GCC doesn't define `sun`.

Tested on 'SunOS solaris 5.11 11.4.0.15.0 i86pc i386 i86pc'

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [ ] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [ ] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
