### PR TITLE
Apply Intel compiler new convention

### DIFF
--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -236,8 +236,8 @@ set "_known_=1"
 goto :eof
 
 :Config_INTEL_WIN32
-if not defined CXX ( set "CXX=icl" )
-set "B2_CXX="%CXX%" /nologo /MT /O2 /Ob2 /Gy /GF /GA /GB /Feb2"
+if not defined CXX ( set "CXX=icx-cl" )
+set "B2_CXX="%CXX%" /nologo /O2 /Ob2 /Gy /GF /GA /Feb2 -fsycl"
 set "_known_=1"
 goto :eof
 


### PR DESCRIPTION
## Proposed changes

`bootstrap.bat intel-win32` doesn't work inside Intel(r) OneAPI Tools console currently. 

## Types of changes

This change allows to bootstrap with Intel compiler.

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [ ] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [ ] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
