### PR TITLE
make repeated 'using X ;' a no-op

### DIFF
--- a/src/tools/asciidoctor.jam
+++ b/src/tools/asciidoctor.jam
@@ -130,6 +130,13 @@ rule init ( command * )
         # TODO: Design and implement a mechanism to resolve generator conflicts.
         generators.override asciidoctor.convert : boostbook.docbook-to-onehtml ;
     }
+    else
+    {
+        if ! $(command)
+        {
+            return ;
+        }
+    }
 
     # The command.. Default is bare asciidoctor.
     command ?= asciidoctor ;

--- a/src/tools/fop.jam
+++ b/src/tools/fop.jam
@@ -17,6 +17,18 @@ generators.register-standard fop.render.ps : FO : PS ;
 #
 rule init ( fop-command ? : java-home ? : java ? )
 {
+    if ! $(.initialized)
+    {
+        .initialized = true ;
+    }
+    else
+    {
+        if ! ( $(1) && $(2) && $(3) )
+        {
+            return ;
+        }
+    }
+
     local has-command = $(.has-command) ;
 
     if $(fop-command)

--- a/src/tools/gettext.jam
+++ b/src/tools/gettext.jam
@@ -62,11 +62,17 @@ rule init ( path ? # Path where all tools are located. If not specified,
                    # they should be in PATH.
           )
 {
-    if $(.initialized) && $(.path) != $(path)
+    if $(.initialized) && ! $(path)
+    {
+        return ;
+    }
+
+    .initialized = true ;
+    if $(.path) != $(path)
     {
         errors.error "Attempt to reconfigure with different path" ;
     }
-    .initialized = true ;
+
     if $(path)
     {
         .path = $(path)/ ;

--- a/src/tools/pkg-config.jam
+++ b/src/tools/pkg-config.jam
@@ -154,7 +154,15 @@ using pkg-config : [config] : [command] ... : [ options ] ... ;
 
 rule init ( config ? : command * : options * )
 {
-    config ?= [ default-config ] ;
+    if ! $(config)
+    {
+        config = [ default-config ] ;
+        if ( $(config) in [ $(.configs).all ] )
+           && ! ( $(command) && $(options) )
+        {
+            return ;
+        }
+    }
 
     local tool = [ os.environ PKG_CONFIG ] ;
     tool ?= pkg-config ;

--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -104,6 +104,18 @@ py3-version = ;
 rule init ( version ? : cmd-or-prefix ? : includes * : libraries ?
     : condition * : extension-suffix ? )
 {
+    if ! $(.initialized)
+    {
+        .initialized = true ;
+    }
+    else
+    {
+        if ! ( $(1) && $(2) && $(3) && $(4) && $(5) && $(6) )
+        {
+            return ;
+        }
+    }
+
     project.push-current $(.project) ;
 
     debug-message Configuring python... ;

--- a/src/tools/sass.jam
+++ b/src/tools/sass.jam
@@ -96,6 +96,13 @@ rule init ( command * )
         # Register generators
         generators.register [ new sass-generator sass.convert : SASS : CSS ] ;
     }
+    else
+    {
+        if ! $(command)
+        {
+            return ;
+        }
+    }
 
     # Setting up command
     if ! $(command)

--- a/src/tools/saxonhe.jam
+++ b/src/tools/saxonhe.jam
@@ -11,6 +11,18 @@ import os ;
 
 rule init ( saxonhe_jar ? : java_exe ? )
 {
+    if ! $(.initialized)
+    {
+        .initialized = true ;
+    }
+    else
+    {
+        if ! ( $(1) && $(2) )
+        {
+            return ;
+        }
+    }
+
     .java_exe = [ common.get-invocation-command saxonhe : java : $(java_exe) :  ] ;
     if $(saxonhe_jar)
     {


### PR DESCRIPTION
This change allows putting `using X ;` into build scripts (as opposed to user configs) without creating a conflicting or wrong setup for module X. This is so that build scripts could rely on toolset modules having been configured (at least with default values).

The commit only updates toolset modules which allow `using` without arguments in the first place. It also does not change toolset modules for C++ compilers, as nobody does e.g. `using gcc ;` in their build scripts anyway.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)