### PR TITLE
cpp is a preprocessor, don't try to compile with it

### DIFF
--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -251,7 +251,7 @@ check_toolset ()
     if test_toolset sunpro && test_compiler /opt/SUNWspro/bin/CC -std=c++11 ; then B2_TOOLSET=sunpro ; return ${TRUE} ; fi
     # Generic (cxx)
     if test_toolset cxx && test_compiler cxx ; then B2_TOOLSET=cxx ; return ${TRUE} ; fi
-    if test_toolset cxx && test_compiler cpp ; then B2_TOOLSET=cxx ; return ${TRUE} ; fi
+    if test_toolset cxx && test_compiler c++ ; then B2_TOOLSET=cxx ; return ${TRUE} ; fi
     if test_toolset cxx && test_compiler CC ; then B2_TOOLSET=cxx ; return ${TRUE} ; fi
 
     # Nothing found.


### PR DESCRIPTION
It dpesn't support multiple input files, leading to an error:
cpp: fatal error: too many input files

Fixes https://github.com/bfgroup/b2/issues/323
Fixes https://github.com/boostorg/build/issues/613
Fixes https://github.com/boostorg/build/issues/614
