### PR TITLE
fix broken multiple configurations for some toolset modules

### DIFF
--- a/src/tools/fop.jam
+++ b/src/tools/fop.jam
@@ -23,7 +23,7 @@ rule init ( fop-command ? : java-home ? : java ? )
     }
     else
     {
-        if ! ( $(1) && $(2) && $(3) )
+        if ! ( $(1) || $(2) || $(3) )
         {
             return ;
         }

--- a/src/tools/pkg-config.jam
+++ b/src/tools/pkg-config.jam
@@ -158,7 +158,7 @@ rule init ( config ? : command * : options * )
     {
         config = [ default-config ] ;
         if ( $(config) in [ $(.configs).all ] )
-           && ! ( $(command) && $(options) )
+           && ! ( $(command) || $(options) )
         {
             return ;
         }

--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -110,7 +110,7 @@ rule init ( version ? : cmd-or-prefix ? : includes * : libraries ?
     }
     else
     {
-        if ! ( $(1) && $(2) && $(3) && $(4) && $(5) && $(6) )
+        if ! ( $(1) || $(2) || $(3) || $(4) || $(5) || $(6) )
         {
             return ;
         }

--- a/src/tools/saxonhe.jam
+++ b/src/tools/saxonhe.jam
@@ -17,7 +17,7 @@ rule init ( saxonhe_jar ? : java_exe ? )
     }
     else
     {
-        if ! ( $(1) && $(2) )
+        if ! ( $(1) || $(2) )
         {
             return ;
         }


### PR DESCRIPTION
## Proposed changes

When making #374 I wrote the checks for some modules incorrectly (wrong application of De Morgan's law). As a result declaring multiple configurations for those modules broke. This PR fixes that.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)