### PR TITLE
allow tag feature for virtual-targets with exact name or without type

### DIFF
--- a/src/build/virtual-target.jam
+++ b/src/build/virtual-target.jam
@@ -282,10 +282,7 @@ class abstract-file-target : virtual-target
         {
             $(action).add-targets $(__name__) ;
 
-            if $(self.type) && ! $(exact)
-            {
-                _adjust-name $(name) ;
-            }
+            _adjust-name $(name) ;
         }
     }
 
@@ -474,8 +471,16 @@ class abstract-file-target : virtual-target
                         : $(tag) ;
                 }
 
-                self.name = [ indirect.call $(rule-name) $(specified-name)
+                local name = [ indirect.call $(rule-name) $(specified-name)
                     : $(self.type) : $(ps) ] ;
+                if $(name)
+                {
+                    self.name = $(name) ;
+                }
+                else
+                {
+                    tag = ;
+                }
             }
             else
             {
@@ -484,8 +489,9 @@ class abstract-file-target : virtual-target
             }
         }
 
-        # If there is no tag or the tag rule returned nothing.
-        if ! $(tag) || ! $(self.name)
+        # If this is a typed target, the name is not requested to be exact,
+        # and there is no tag or the tag rule returned nothing.
+        if $(self.type) && ! $(exact) && ! $(tag)
         {
             self.name = [ virtual-target.add-prefix-and-suffix $(specified-name)
                 : $(self.type) : $(ps) ] ;

--- a/test/tag.py
+++ b/test/tag.py
@@ -71,6 +71,7 @@ rule tag ( name : type ? : property-set )
         case SHARED_LIB : tags += _dll ;
         case STATIC_LIB : tags += _lib ;
         case EXE        : tags += _exe ;
+        case *          : tags = ;
     }
     if $(tags)
     {


### PR DESCRIPTION
## Proposed changes

Allow `<tag>` feature to run on virtual targets with `exact` name or without type.

Currently `<tag>` is disabled on `make` targets and other targets with `exact` name or without type. This makes it unnecessary hard to  create targets which has name that depends on the property set. I looked at the history of this behaviour, and it seems to be a remnant of not adding type affixes to sucha targets. At one point `<tag>` handling was added, but the check for having a type and not having an `exact` name remained.

## Types of changes

- [X] New feature (non-breaking change which adds functionality)

## Alternative

Alternative approach is to keep `<tag>` disabled when name is `exact`, and just change `make` targets to not set name to `exact`.