### PR TITLE
msvc: recognize Visual Studio 2022 v17.10.0, which uses toolchain version 14.40.33807

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -23,6 +23,7 @@ https://docs.microsoft.com/en-us/cpp/[Microsoft Visual C++] command-line
 tools on Microsoft Windows. The supported products and versions of
 command line tools are listed below:
 
+* Visual Studio 2022-14.3
 * Visual Studio 2019-14.2
 * Visual Studio 2017—14.1
 * Visual Studio 2015—14.0
@@ -1119,7 +1120,7 @@ local rule generate-setup-cmd ( version : command : parent : options * : cpu : g
         }
         else
         {
-            if [ MATCH "(14.3)" : $(version) ]
+            if [ MATCH "(14.[34])" : $(version) ]
             {
                 if $(.debug-configuration)
                 {
@@ -1298,7 +1299,7 @@ local rule configure-really ( version ? : options * )
             # version from the path.
             # FIXME: We currently detect both Microsoft Visual Studio 9.0 and
             # 9.0express as 9.0 here.
-            if [ MATCH "(MSVC\\\\14.3)" : $(command) ]
+            if [ MATCH "(MSVC\\\\14.[34])" : $(command) ]
             {
                 version = 14.3 ;
             }


### PR DESCRIPTION
## Proposed changes

Fixes #391. Visual Studio 2022 v17.10.0 introduced a new toolchain version 14.40.33807, which does not start with "14.3". This trips up the `cl.exe` finding logic in `msvc.jam`.

As discussed in #391, it is really a bad move of Microsoft to bump their toolchain version that way, but since you cannot have Visual Studio 2022 v17.9.x and v17.10.x installed side-by-side, I think it does not make much sense to introduce a `msvc-14.4` toolset in b2.

Therefore, I would propose to recognize toolchain versions starting with "14.4" also as `msvc-14.3`, which is a relatively small change.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)
