### PR TITLE
fix doxygen's treatment of source paths

### DIFF
--- a/src/tools/doxygen.jam
+++ b/src/tools/doxygen.jam
@@ -309,8 +309,14 @@ rule headers-to-doxyfile ( target : sources * : properties * )
     }
 
     local headers ;
-    for local header in $(sources:G=)
+    for local source in $(sources)
     {
+        local header = $(source:G=) ;
+        local root = [ on $(source) return $(SEARCH) ] ;
+        if $(root)
+        {
+            header = [ path.root $(header) $(root) ] ;
+        }
         header = [ translate-path $(header) ] ;
         headers += \"$(header)\" ;
     }


### PR DESCRIPTION
## Proposed changes

`doxygen.headers-to-doxyfile` creates a Doxygen configuration file and populates its `INPUT` value with the paths to its sources. But when doing so it does not take into account the full path to those sources, only the part that is used in the source name without the grist. The resulting file is only correct when either the provided path to a source is absolute, or when the path is relative to CWD. Some globbing functions return relative paths. And the sources for docs usually searched from the doc subdir, not from CWD.

This change fixes that issue by having `headers-to-doxyfile` to prefix paths to sources with their `SEARCH` variables.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

## Further comments

An alternative fix would be to make the paths which are put into the resulting Doxygen config file absolute. This change would be potentially slightly more disruptive, but has some potential benefits.