### PR TITLE
fix staging

### DIFF
--- a/src/tools/stage.jam
+++ b/src/tools/stage.jam
@@ -798,7 +798,7 @@ rule get-dir ( name : property-set : package-name : flags * )
             local rel = [ path.relative $(result) $(prefix) : no-error ] ;
             if not-a-child != $(rel)
             {
-                result = [ path.root $(rel) $(prefix) ] ;
+                result = [ path.root $(rel) $(stage) ] ;
             }
         }
     }


### PR DESCRIPTION
## Proposed changes

Due to a typo staging using `<staging-prefix> is broken. This change removes the typo.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)