### PR TITLE
toolset.using preserves current project

### DIFF
--- a/src/build/project.jam
+++ b/src/build/project.jam
@@ -1276,8 +1276,6 @@ module project-rules
     {
         import toolset ;
 
-        local saved-project = [ modules.peek project : .current-project ] ;
-
         # Temporarily change the search path so the module referred to by
         # 'using' can be placed in the same directory as Jamfile. User will
         # expect the module to be found even though the directory is not in
@@ -1290,13 +1288,6 @@ module project-rules
             $(9) : $(10) : $(11) : $(12) : $(13) : $(14) : $(15) : $(16) : $(17)
             : $(18) : $(19) ;
         modules.poke : BOOST_BUILD_PATH : $(x) ;
-
-        # The above might have clobbered .current-project in case it caused a
-        # new project instance to be created (which would then automatically
-        # get set as the 'current' project). Restore the correct value so any
-        # main targets declared after this do not get mapped to the loaded
-        # module's project.
-        modules.poke project : .current-project : $(saved-project) ;
     }
 
     rule import ( * : * : * )

--- a/src/build/toolset.jam
+++ b/src/build/toolset.jam
@@ -39,9 +39,18 @@ if --ignore-toolset-requirements in [ modules.peek : ARGV ]
 #
 rule using ( toolset-module : * )
 {
+    local saved-project = [ modules.peek project : .current-project ] ;
+
     import $(toolset-module) ;
     $(toolset-module).init $(2) : $(3) : $(4) : $(5) : $(6) : $(7) : $(8) : $(9)
         ;
+
+    # The above might have clobbered .current-project in case it caused a
+    # new project instance to be created (which would then automatically
+    # get set as the 'current' project). Restore the correct value so any
+    # main targets declared after this do not get mapped to the loaded
+    # module's project.
+    modules.poke project : .current-project : $(saved-project) ;
 }
 
 


### PR DESCRIPTION
## Proposed changes

`using` project rule preserves the current project, and `toolset.using` does not. The problem is that the former is not available in modules that are not projects, and so one has to preserve the current project manually, just in case. I don't think there is ever any point in not preserving the current project when initialising a toolset module, so this change pushes this reponsibility on `toolset.using`.

## Types of changes

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [X] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [X] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [X] I checked that tests pass locally with my changes