### PR TITLE
fix getting caller module

### DIFF
--- a/src/build/project.jam
+++ b/src/build/project.jam
@@ -161,8 +161,11 @@ rule find ( name : current-location )
             local jamfile = $(root-and-jamfile[2]) ;
             if $(root)
             {
-                local caller-project = [ CALLER_MODULE ] ;
-                local caller-module = [ $(caller-project).project-module ] ;
+                local caller-module = [ CALLER_MODULE ] ;
+                if [ class.is-a $(caller-module) project-target ]
+                {
+                    caller-module = [ $(caller-module).project-module ] ;
+                }
                 if $(jamfile)
                 {
                     modules.call-in $(caller-module)


### PR DESCRIPTION
## Proposed changes

This fix allows calling `project.find` from a project module directly (as opposed to being called from a corresponding target instance).

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)