### PR TITLE
Make regexes for scanning include/import statements consistent

### DIFF
--- a/src/tools/rc.jam
+++ b/src/tools/rc.jam
@@ -93,6 +93,7 @@ class res-scanner : scanner
     import path ;
     import regex ;
     import scanner ;
+    import sequence ;
     import toolset ;
     import virtual-target ;
 
@@ -108,13 +109,15 @@ class res-scanner : scanner
 
     rule pattern ( )
     {
-        return "(([^ ]+[ ]+(BITMAP|CURSOR|FONT|ICON|MESSAGETABLE|RT_MANIFEST)[ ]+([^ \"]+|\"[^\"]+\"))|(#include[ ]*(<[^<]+>|\"[^\"]+\")))" ;
+        return "(([^ ]+[ ]+(BITMAP|CURSOR|FONT|ICON|MESSAGETABLE|RT_MANIFEST)[ ]+([^ \"]+|\"[^\"]+\"))|(^[ \t]*#[ \t]*include[ \t]*(<[^<]+>|\"[^\"]+\")))" ;
     }
 
     rule process ( target : matches * : binding )
     {
-        local angle = [ regex.transform $(matches) : "#include[ ]*<([^<]+)>" ] ;
-        local quoted = [ regex.transform $(matches) : "#include[ ]*\"([^\"]+)\"" ] ;
+        local angle = [ regex.transform $(matches) : "#include[ \t]*<([^<]+)>" ] ;
+        angle = [ sequence.transform path.native : $(angle) ] ;
+        local quoted = [ regex.transform $(matches) : "#include[ \t]*\"([^\"]+)\"" ] ;
+        quoted = [ sequence.transform path.native : $(quoted) ] ;
         local res = [ regex.transform $(matches) : "[^ ]+[ ]+(BITMAP|CURSOR|FONT|ICON|MESSAGETABLE|RT_MANIFEST)[ ]+(([^ \"]+)|\"([^\"]+)\")" : 3 4 ] ;
 
         # Icons and other includes may be referenced as

--- a/src/tools/types/cpp.jam
+++ b/src/tools/types/cpp.jam
@@ -30,14 +30,14 @@ class c-scanner : scanner
 
     rule pattern ( )
     {
-        return "^[ \t]*#[ \t]*include[ \t]*(<(.+)>|\"(.+)\")" ;
+        return "^[ \t]*#[ \t]*include[ \t]*(<[^<]+>|\"[^\"]+\")" ;
     }
 
     rule process ( target : matches * : binding )
     {
-        local angle = [ regex.transform $(matches) : "<(.*)>" ] ;
+        local angle = [ regex.transform $(matches) : "<([^<]+)>" ] ;
         angle = [ sequence.transform path.native : $(angle) ] ;
-        local quoted = [ regex.transform $(matches) : "\"(.*)\"" ] ;
+        local quoted = [ regex.transform $(matches) : "\"([^\"]+)\"" ] ;
         quoted = [ sequence.transform path.native : $(quoted) ] ;
 
         # CONSIDER: the new scoping rules seem to defeat "on target" variables.

--- a/src/tools/types/objc.jam
+++ b/src/tools/types/objc.jam
@@ -14,7 +14,7 @@ class objc-scanner : c-scanner
 
     rule pattern ( )
     {
-        return "^[ \t]*#[ \t]*include|import[ ]*(<(.+)>|\"(.+)\")" ;
+        return "^[ \t]*#[ \t]*(include|import)[ \t]*(<[^<]+>|\"[^\"]+\")" ;
     }
 }
 


### PR DESCRIPTION
## Proposed changes

For res-scanner, add `^[ \t]*` before and `[ \t]*` after the `include` word. This matches what was done in 13b8a68 for c-scanner and objc-scanner. Also use `sequence.transform path.native` for the `angle` and `quoted` results, similar to cpp-scanner.

For cpp-scanner, use `[^<]+` to match characters for angled includes, and `[^\"]+` for quoted includes, similar to what was done in res-scanner. This ensures strings like `#include <foo> bar>` will not match.

For objc-scanner, idem as for cpp-scanner.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)
