### PR TITLE
Fix Building on Haiku OS

### DIFF
--- a/src/engine/execunix.cpp
+++ b/src/engine/execunix.cpp
@@ -537,9 +537,16 @@ void exec_wait()
                     close_streams( i, ERR );
 
                 /* Reap the child and release resources. */
+            #ifdef __HAIKU__
+                while ((pid = waitpid(cmdtab[i].pid, &status, 0)) == -1)
+                    if (errno != EINTR)
+                        break;
+                getrusage(RUSAGE_CHILDREN, &cmd_usage);
+            #else
                 while ( ( pid = wait4( cmdtab[ i ].pid, &status, 0, &cmd_usage ) ) == -1 )
                     if ( errno != EINTR )
                         break;
+            #endif
                 if ( pid != cmdtab[ i ].pid )
                 {
                     err_printf( "unknown pid %d with errno = %d\n", pid, errno );


### PR DESCRIPTION
Fix Building  on Haiku OS:

wait4 is not found on Haiku system call, use waitpid + getrusage instead.