### PR TITLE
<location> support for asciidoctor and sass targets

### DIFF
--- a/src/tools/asciidoctor.jam
+++ b/src/tools/asciidoctor.jam
@@ -193,7 +193,7 @@ class asciidoctor-generator : generator
         for local p in [ $(property-set).raw ]
         {
             if $(p:G) in <asciidoctor-attribute> <asciidoctor-doctype>
-                <flags>
+                <flags> <location>
             {
                 raw-set += $(p) ;
             }

--- a/src/tools/sass.jam
+++ b/src/tools/sass.jam
@@ -173,7 +173,7 @@ class sass-generator : generator
     local rule recognized-feature ( feature )
     {
         local result ;
-        if $(feature:G) in <include> <flags>
+        if $(feature:G) in <include> <flags> <location>
         {
           result = true ;
         }


### PR DESCRIPTION
## Proposed changes

`<location>` is removed from  property sets for SASS and ASCIIDOC targets. This makes them behave differently from other targets, and prevents users to put them into a specific place. Normally it can be circumvented using an `install` rule, but when multiple files are created it becomes less trivial. The change fixes the issue by whitelisting `<location>` feature for those types.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [X] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [X] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [X] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [X] I added myself to the copyright attributions for significant changes
- [X] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)
