### PR TITLE
Fix version regex pattern in msvc.jam

### DIFF
--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -1340,15 +1340,15 @@ local rule configure-really ( version ? : options * )
             # version from the path.
             # FIXME: We currently detect both Microsoft Visual Studio 9.0 and
             # 9.0express as 9.0 here.
-            if [ MATCH "(MSVC\\\\14.[34])" : $(command) ]
+            if [ MATCH "(MSVC(\\/|\\\\)14.[34])" : $(command) ]
             {
                 version = 14.3 ;
             }
-            else if [ MATCH "(MSVC\\\\14.2)" : $(command) ]
+            else if [ MATCH "(MSVC(\\/|\\\\)14.2)" : $(command) ]
             {
                 version = 14.2 ;
             }
-            else if [ MATCH "(MSVC\\\\14.1)" : $(command) ]
+            else if [ MATCH "(MSVC(\\/|\\\\)14.1)" : $(command) ]
             {
                 version = 14.1 ;
             }


### PR DESCRIPTION
Commands should use forward-slashes according to documentation

## Proposed changes

In [msvc.jam#L63-L64](https://github.com/bfgroup/b2/blob/f518c83dbbcce621df81ab29e7b2a33498a35ca2/src/tools/msvc.jam#L63-L64) it says that compiler commands should use forward slashes instead of backslashes.

However, at [msvc.jam#L1343-L1351](https://github.com/bfgroup/b2/blob/f518c83dbbcce621df81ab29e7b2a33498a35ca2/src/tools/msvc.jam#L1343-L1351) the regex patterns to extract the toolset version from the command expect backslashes.

This PR adapts the regex patterns so that they work for paths with forward slashes, as well as backslashes.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

