### PR TITLE
Initial vc145 support

### DIFF
--- a/src/engine/build.bat
+++ b/src/engine/build.bat
@@ -29,7 +29,7 @@ ECHO ###     .\build.bat msvc
 ECHO ###
 ECHO ### Toolsets supported by this script are: borland, como, gcc,
 ECHO ###     clang, clang-win, gcc-nocygwin, intel-win32, mingw,
-ECHO ###     vc12, vc14, vc141, vc142, vc143
+ECHO ###     vc12, vc14, vc141, vc142, vc143, vc145
 ECHO ###
 ECHO ### If you have Visual Studio 2017 installed you will need to either update
 ECHO ### the Visual Studio 2017 installer or run from VS 2017 Command Prompt

--- a/src/engine/config_toolset.bat
+++ b/src/engine/config_toolset.bat
@@ -12,6 +12,7 @@ if "_%B2_TOOLSET%_" == "_vc14_" call :Config_VC14
 if "_%B2_TOOLSET%_" == "_vc141_" call :Config_VC141
 if "_%B2_TOOLSET%_" == "_vc142_" call :Config_VC142
 if "_%B2_TOOLSET%_" == "_vc143_" call :Config_VC143
+if "_%B2_TOOLSET%_" == "_vc145_" call :Config_VC145
 if "_%B2_TOOLSET%_" == "_borland_" call :Config_BORLAND
 if "_%B2_TOOLSET%_" == "_como_" call :Config_COMO
 if "_%B2_TOOLSET%_" == "_gcc_" call :Config_GCC
@@ -140,6 +141,28 @@ set "_known_=1"
 goto :Embed_Minafest_Via_Link
 
 :Config_VC143
+if not defined CXX ( set "CXX=cl" )
+call vswhere_usability_wrapper.cmd
+REM Reset ERRORLEVEL since from now on it's all based on ENV vars
+ver > nul 2> nul
+if "_%B2_TOOLSET_ROOT%_" == "__" (
+    if NOT "_%VS170COMNTOOLS%_" == "__" (
+        set "B2_TOOLSET_ROOT=%VS170COMNTOOLS%..\..\VC\"
+    ))
+
+if "_%B2_ARCH%_" == "__" set B2_ARCH=%PROCESSOR_ARCHITECTURE%
+set B2_BUILD_ARGS=%B2_BUILD_ARGS% %B2_ARCH%
+
+REM return to current directory as vsdevcmd_end.bat switches to %USERPROFILE%\Source if it exists.
+pushd %CD%
+if "_%VSINSTALLDIR%_" == "__" call :Call_If_Exists "%B2_TOOLSET_ROOT%Auxiliary\Build\vcvarsall.bat" %B2_BUILD_ARGS%
+popd
+set "B2_CXX="%CXX%" /nologo /MP /MT /TP /Feb2 /wd4996 /wd4675 /O2 /GL /EHsc /Zc:wchar_t /Gw"
+set "B2_CXX_LINK=/link kernel32.lib advapi32.lib user32.lib"
+set "_known_=1"
+goto :Embed_Minafest_Via_Link
+
+:Config_VC145
 if not defined CXX ( set "CXX=cl" )
 call vswhere_usability_wrapper.cmd
 REM Reset ERRORLEVEL since from now on it's all based on ENV vars

--- a/src/engine/guess_toolset.bat
+++ b/src/engine/guess_toolset.bat
@@ -33,6 +33,10 @@ REM Let vswhere tell us where msvc is at, if available.
 call :Clear_Error
 call vswhere_usability_wrapper.cmd
 call :Clear_Error
+if NOT "_%VS180COMNTOOLS%_" == "__" (
+    set "B2_TOOLSET=vc145"
+    set "B2_TOOLSET_ROOT=%VS180COMNTOOLS%..\..\VC\"
+    goto :eof)
 if NOT "_%VS170COMNTOOLS%_" == "__" (
     set "B2_TOOLSET=vc143"
     set "B2_TOOLSET_ROOT=%VS170COMNTOOLS%..\..\VC\"

--- a/src/tools/msvc.jam
+++ b/src/tools/msvc.jam
@@ -23,6 +23,7 @@ https://docs.microsoft.com/en-us/cpp/[Microsoft Visual C++] command-line
 tools on Microsoft Windows. The supported products and versions of
 command line tools are listed below:
 
+* Visual Studio 2026-14.5
 * Visual Studio 2022-14.3
 * Visual Studio 2019-14.2
 * Visual Studio 2017—14.1
@@ -1154,7 +1155,15 @@ local rule generate-setup-cmd ( version : command : parent : options * : cpu : g
         }
         else
         {
-            if [ MATCH "(14.[34])" : $(version) ]
+            if [ MATCH "(14.5)" : $(version) ]
+            {
+                if $(.debug-configuration)
+                {
+                    ECHO "notice: [generate-setup-cmd] $(version) is 14.5" ;
+                }
+                parent = [ path.native [ path.join  $(parent) "..\\..\\..\\..\\..\\Auxiliary\\Build" ] ] ;
+            }
+            else if [ MATCH "(14.[34])" : $(version) ]
             {
                 if $(.debug-configuration)
                 {
@@ -1340,7 +1349,11 @@ local rule configure-really ( version ? : options * )
             # version from the path.
             # FIXME: We currently detect both Microsoft Visual Studio 9.0 and
             # 9.0express as 9.0 here.
-            if [ MATCH "(MSVC(\\/|\\\\)14.[34])" : $(command) ]
+			if [ MATCH "(MSVC(\\/|\\\\)14.5)" : $(command) ]
+            {
+                version = 14.5 ;
+            }
+            else if [ MATCH "(MSVC(\\/|\\\\)14.[34])" : $(command) ]
             {
                 version = 14.3 ;
             }
@@ -1767,13 +1780,17 @@ local rule default-path ( version )
         # And fortunately, forward slashes do also work in native Windows.
         local vswhere = "$(root)/Microsoft Visual Studio/Installer/vswhere.exe" ;
         # The check for $(root) is to avoid a segmentation fault if not found.
-        if $(version) in 14.1 14.2 14.3 default && $(root) && [ path.exists $(vswhere) ]
+        if $(version) in 14.1 14.2 14.3 14.5 default && $(root) && [ path.exists $(vswhere) ]
         {
             local req = "-requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64" ;
             local prop = "-property installationPath" ;
             local limit ;
 
-            if $(version) = 14.3
+            if $(version) = 14.5
+            {
+                limit = "-version \"[18.0,19.0)\" -prerelease" ;
+            }
+            else if $(version) = 14.3
             {
                 limit = "-version \"[17.0,18.0)\" -prerelease" ;
             }
@@ -2197,7 +2214,7 @@ for local arch in [ MATCH "^\\.cpus-on-(.*)" : [ VARNAMES $(__name__) ] ]
                      armv7 armv7s ;
 
 # Known toolset versions, in order of preference.
-.known-versions = 14.3 14.2 14.1 14.0 12.0 11.0 10.0 10.0express 9.0 9.0express 8.0 8.0express 7.1
+.known-versions = 14.5 14.3 14.2 14.1 14.0 12.0 11.0 10.0 10.0express 9.0 9.0express 8.0 8.0express 7.1
     7.1toolkit 7.0 6.0 ;
 
 # Version aliases.
@@ -2249,6 +2266,11 @@ for local arch in [ MATCH "^\\.cpus-on-(.*)" : [ VARNAMES $(__name__) ] ]
     "Microsoft Visual Studio/2022/*/VC/Tools/MSVC/*/bin/Host*/*"
     ;
 .version-14.3-env = VS170COMNTOOLS ProgramFiles ProgramFiles(x86) ;
+.version-14.5-path =
+    "../../VC/Tools/MSVC/*/bin/Host*/*"
+    "Microsoft Visual Studio/2026/*/VC/Tools/MSVC/*/bin/Host*/*"
+    ;
+.version-14.5-env = VS180COMNTOOLS ProgramFiles ProgramFiles(x86) ;
 
 
 # And finally trigger the actual Boost Build toolset registration.


### PR DESCRIPTION
## Proposed changes

This month [Microsoft released a preview for Visual Studio 2026 (VS 18.0)](https://visualstudio.microsoft.com/insiders/), and its toolset vc145. This PR adds rudimentary support allowing b2 to recognize it, based on vc143 settings.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [x] I added necessary documentation (if appropriate)

## Further comments

Tested with a build of boost-1.89.0 with `.\b2 install --build-type=complete cxxstd=latest address-model=64 release/lto=on release/lto-mode=thin release/vectorize=full`
Example: `msvc.archive E:\tmp\boost-build-vc145\boost\bin.v2\libs\stacktrace\build\msvc-14.5\release\x86_64\cxxstd-latest-iso\link-static\lto-on-full\threading-multi\libboost_stacktrace_noop-vc145-mt-x64-1_89.lib`