### PR TITLE
propagate dll-path to shared libraries

### DIFF
--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -1070,7 +1070,7 @@ actions link bind LIBRARIES
 
 actions link.dll bind LIBRARIES
 {
-    "$(CONFIG_COMMAND)" @($(<[1]:T).rsp:O=FC:<=@":>=":E=-L"$(LINKPATH)" -Wl,$(RPATH_OPTION)$(SPACE)-Wl,$(RPATH) -Wl,$(IMPLIB_OPTION:E=--out-implib),"$(<[2]:T)" -o "$(<[1]:T)" $(HAVE_SONAME)-Wl,$(SONAME_OPTION)$(SPACE)-Wl,"$(SONAME_PREFIX:E=)$(<[1]:D=)" $(SHARED_OPTION:E=-shared) $(START-GROUP) "$(>:T)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS))
+    "$(CONFIG_COMMAND)" @($(<[1]:T).rsp:O=FC:<=@":>=":E=-L"$(LINKPATH)" -Wl,$(RPATH_OPTION)$(SPACE)-Wl,$(RPATH) -Wl,-rpath-link$(SPACE)-Wl,"$(RPATH_LINK)" -Wl,-rpath-link$(SPACE)-Wl,"$(RPATH_LINK)" -Wl,$(IMPLIB_OPTION:E=--out-implib),"$(<[2]:T)" -o "$(<[1]:T)" $(HAVE_SONAME)-Wl,$(SONAME_OPTION)$(SPACE)-Wl,"$(SONAME_PREFIX:E=)$(<[1]:D=)" $(SHARED_OPTION:E=-shared) $(START-GROUP) "$(>:T)" "$(LIBRARIES)" $(FINDLIBS-ST-PFX) -l$(FINDLIBS-ST) $(FINDLIBS-SA-PFX) -l$(FINDLIBS-SA) $(END-GROUP) $(OPTIONS) $(USER_OPTIONS))
 }
 
 ###

--- a/src/tools/generators/linking-generator.jam
+++ b/src/tools/generators/linking-generator.jam
@@ -65,8 +65,12 @@ class linking-generator : generator
         # Pros: do not need to relink libraries when installing.
         # Cons: "standalone" libraries (plugins, python extensions) can not
         # hardcode paths to dependent libraries.
+        local target-type = $(self.target-types[1]) ;
         if [ $(property-set).get <hardcode-dll-paths> ] = true
-            && [ type.is-derived $(self.target-types[1]) EXE ]
+            && (
+                [ type.is-derived $(target-type) EXE ]
+                || [ type.is-derived $(target-type) SHARED_LIB ]
+            )
         {
             local xdll-path = [ $(property-set).get <xdll-path> ] ;
             extra += <dll-path>$(xdll-path) <dll-path>$(extra-xdll-paths) ;


### PR DESCRIPTION
## Proposed changes

Put paths to dependencies into DT_RUNPATH section of shared libraries.

In a situation like this:
```
# a/build.jam
project /a ;
lib a : a.cpp;

# b/build.jam
project /b ;
lib b : b.cpp /a//a ;

# c/build.jam
project /c ;
run c.cpp /b//b ;
```

the executable `c` needs to know where to search for the shared library `a`. This is done with DT_RPATH and DT_RUNPATH sections of the binary. GNU ld sets both by default. This makes the loader ignore RPATH in favour of RUNPATH. The loader also _only considers RUNPATH of the binary that causes the search_ (https://en.wikipedia.org/wiki/Rpath#The_role_of_GNU_ld). This is considered a security feature.

This problem has apparently been known since at least 2011:
* https://www.qt.io/blog/2011/10/28/rpath-and-runpath;
* https://bugs.launchpad.net/ubuntu/+source/eglibc/+bug/1253638.

b2 currently does not set RUNPATH on shared libraries. Due to this the loader wouldn't be able to find the library `a` from the executable `c`, unless the executable links to `a` directly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)