### PR TITLE
Reduce the requirements on the ARM FPU options.

### DIFF
--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -1292,10 +1292,10 @@ cpu-flags gcc OPTIONS : s390x : z13 : -march=z13 ;
 cpu-flags gcc OPTIONS : s390x : z14 : -march=z14 ;
 cpu-flags gcc OPTIONS : s390x : z15 : -march=z15 ;
 # ARM
-cpu-flags gcc OPTIONS : arm : cortex-a9+vfpv3 : -mcpu=cortex-a9 -mfpu=vfpv3 -mfloat-abi=hard ;
+cpu-flags gcc OPTIONS : arm : cortex-a9+vfpv3 : -mcpu=cortex-a9 -mfpu=vfpv3 ;
 cpu-flags gcc OPTIONS : arm : cortex-a53 : -mcpu=cortex-a53 ;
 cpu-flags gcc OPTIONS : arm : cortex-r5 : -mcpu=cortex-r5 ;
-cpu-flags gcc OPTIONS : arm : cortex-r5+vfpv3-d16 : -mcpu=cortex-r5 -mfpu=vfpv3-d16 -mfloat-abi=hard ;
+cpu-flags gcc OPTIONS : arm : cortex-r5+vfpv3-d16 : -mcpu=cortex-r5 -mfpu=vfpv3-d16 ;
 # AIX variant of RS/6000 & PowerPC
 toolset.flags gcc AROPTIONS <address-model>64/<target-os>aix : "-X64" ;
 


### PR DESCRIPTION
## Proposed changes

This removes over-specified flags for GCC with the given instruction sets.  The floating-point ABI when using the FPU can be `hard` or `softfp`.  The `<floating-point-abi>` feature should really be used to control this.  As it is, any use of these instruction sets forces the `hard` floating-point ABI though (and disallows others since the command-line then contains both `-mfloat-abi=hard` and `-mfloat-abi=softfp`, which conflict in the compiler and cause various problems.

Yes, I am the person who added these over-specified flags and it's breaking the very thing I added these for, but have not used a more recent B2 until recently.  There does not seem to be a workaround either, so this was a pretty bad thing to do.

## Types of changes

Removes some flags, this may break users that depend on this (erroneous) behavior, but also enables uses that require that the `<floating-point-abi>` is not specified.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [ ] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I added necessary documentation (if appropriate)
