### PR TITLE
Fix option module regression

### DIFF
--- a/src/util/option.jam
+++ b/src/util/option.jam
@@ -23,6 +23,14 @@ rule get ( name : default-value ? : implied-value ? )
     if ! $(m) && ! [ args.has-arg $(name) ]
     {
         m = [ MATCH --$(name)=(.*) : [ modules.peek : ARGV ] ] ;
+        if ! $(m)
+        {
+            m = [ MATCH (--$(name)) : [ modules.peek : ARGV ] ] ;
+            if $(m)
+            {
+                m = true ;
+            }
+        }
     }
     if $(m) && $(m) != true
     {


### PR DESCRIPTION
## Proposed changes

Fixes `option.get` not handling `--arg` kind of arguments properly. In particular, fixes #469.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)