### PR TITLE
fix building with free threaded python

### DIFF
--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -561,6 +561,11 @@ local rule compute-default-paths ( target-os : version ? : prefix ? :
     else
     {
         local default-include-path = $(prefix)/include/python$(version) ;
+        if ! [ path.exists $(default-include-path) ] && [ path.exists $(default-include-path)t ]
+        {
+            default-include-path = $(default-include-path)t ;
+        }
+
         if ! [ path.exists $(default-include-path) ] && [ path.exists $(default-include-path)m ]
         {
             default-include-path = $(default-include-path)m ;


### PR DESCRIPTION
## Proposed changes
Python 3.14 has been releases with the official support with the freethread mode, which allow to run python without the GIL lock.
This PR enables to build boost on the freethread python environment.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments
As the comment on the PR #4 said, the better solution is to use python -c "from sysconfig import get_paths as gp; print(gp()['include'])" as the default include path. I can't implement this solution either, just did this to build and use b2 on a LFS system built with freethreaded python.