### PR TITLE
libstdc++ value for stdlib

### DIFF
--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -174,8 +174,8 @@ toolset.flags clang-linux.compile OPTIONS <lto>on/<lto-mode>full : -flto=full ;
 toolset.flags clang-linux.link OPTIONS <lto>on/<lto-mode>full : -flto=full ;
 
 # stdlib selection
-toolset.flags clang-linux.compile.c++ OPTIONS <stdlib>gnu <stdlib>gnu11 : -stdlib=libstdc++ ;
-toolset.flags clang-linux.link OPTIONS <stdlib>gnu <stdlib>gnu11 : -stdlib=libstdc++ ;
+toolset.flags clang-linux.compile.c++ OPTIONS <stdlib>gnu <stdlib>gnu11 <stdlib>libstdc++ : -stdlib=libstdc++ ;
+toolset.flags clang-linux.link OPTIONS <stdlib>gnu <stdlib>gnu11 <stdlib>libstdc++ : -stdlib=libstdc++ ;
 
 toolset.flags clang-linux.compile.c++ OPTIONS <stdlib>libc++ : -stdlib=libc++ ;
 toolset.flags clang-linux.link OPTIONS <stdlib>libc++ : -stdlib=libc++ ;

--- a/src/tools/embarcadero.jam
+++ b/src/tools/embarcadero.jam
@@ -150,6 +150,7 @@ toolset.inherit-flags embarcadero
       <link>shared
       <threading>multi
       <threading>multi/<target-os>windows
+      <stdlib>libstdc++
       <stdlib>gnu
       <stdlib>gnu11
       <stdlib>libc++

--- a/src/tools/features/stdlib-feature.jam
+++ b/src/tools/features/stdlib-feature.jam
@@ -8,14 +8,16 @@ import feature ;
 #| tag::doc[]
 
 [[b2.builtin.features.stdlib]]`stdlib`::
-*Allowed values*: `native`, `gnu`, `gnu11`, `libc++`, `sun-stlport`, `apache`.
+*Allowed values*: `native`, `libstdc++`, `gnu`, `gnu11`, `libc++`,
+`sun-stlport`, `apache`.
 +
 Specifies C++ standard library to link to and in some cases the library ABI to
 use:
 +
 `native`::: Use compiler's default.
-`gnu`::: Use GNU Standard Library (a.k.a. pass:[libstdc++]) with the old ABI.
-`gnu11`::: Use GNU Standard Library with the new ABI.
+`libstdc++`::: Use GNU Standard Library (a.k.a. pass:[libstdc++]).
+`gnu`::: Use GNU Standard Library and explicitly enable the old ABI.
+`gnu11`::: Use GNU Standard Library and explicitly enable the new ABI.
 `libc++`::: Use LLVM pass:[libc++].
 `sun-stlport`::: Use the STLport implementation of the standard library
   provided with the Solaris Studio compiler.
@@ -25,5 +27,5 @@ use:
 |# # end::doc[]
 
 feature.feature stdlib
-    : native gnu gnu11 libc++ sun-stlport apache
+    : native libstdc++ gnu gnu11 libc++ sun-stlport apache
     : propagated composite ;


### PR DESCRIPTION
## Proposed changes

Allows `<stdlib>libstdc++` in build scripts and `stdlib=libstdc++` from command line to explicitly select libstdc++ as the standard library implementation.

Fix #477.

## Types of changes

- [X] New feature (non-breaking change which adds functionality)