### PR TITLE
[emscripten] Add support for wasm64

### DIFF
--- a/src/tools/emscripten.jam
+++ b/src/tools/emscripten.jam
@@ -186,3 +186,7 @@ toolset.flags emscripten.link OPTIONS <closure>full : --closure 2 ;
 # things for old fastcomp backend which was removed in 2.0.0 (08/10/2020)
 toolset.flags emscripten.link OPTIONS <link-optimization>on : --llvm-lto 1 ;
 toolset.flags emscripten.link OPTIONS <link-optimization>full : --llvm-lto 3 ;
+
+# Memory64/wasm64 support
+toolset.flags emscripten.compile OPTIONS <address-model>64 : -sMEMORY64=1 ;
+toolset.flags emscripten.link    OPTIONS <address-model>64 : -sMEMORY64=1 ;


### PR DESCRIPTION
## Proposed changes

Hello! 

This PR is a follow-up of #310, by adding better support for wasm64.

It adds automatic wasm64 support to the Emscripten toolset by setting `-sMEMORY64=1` when `address-model=64` is specified, eliminating the need for users to manually pass this 
flag via b2 options `cxxflags` and `linkflags`.

It was originally reported on ConanCenterIndex: https://github.com/conan-io/conan-center-index/issues/28839. The case was someone to cross-building from Linux to Emscripten, but using 64-bit architecture (wasm64).

As the Conan recipe is huge, I prepared a very small case to reproduce:

```bash
#!/bin/bash

set -ex

wget -q https://archives.boost.io/release/1.89.0/source/boost_1_89_0.tar.bz2
tar jxf boost_1_89_0.tar.bz2
cd boost_1_89_0/

./bootstrap.sh --with-libraries=regex --prefix=./boost_install

./b2 --version

EMSCRIPTEN=/home/uilian/.conan2/p/emsdkc9782d7aefec5/p/bin/upstream/emscripten
CXX=${EMSCRIPTEN}/em++
CC=${EMSCRIPTEN}/emcc
AR=${EMSCRIPTEN}/emar

$CC --version
$CXX --version
$AR --version

cat > user-config.jam << EOF

using "emscripten" :  :  "${CXX}" :
<archiver>"${AR}"
  ;
EOF

./b2 address-model=64 --user-config=${PWD}/user-config.jam toolset=emscripten link=shared install -d2 --debug-configuration --abbreviate-paths 
```

After running this script on Linux, you may find a similar output log: [boost-1.89.0-wasm-no-patch.log](https://github.com/user-attachments/files/24081498/boost-1.89.0-wasm-no-patch.log)


Here, boost 1.89.0 is built for emscripten, using `address-model=64`, so it's expected to have wasm64 as the target. However, it does not happen; it's possible to find `default address-model    : 32-bit` and the compilation line can be translated to:

```
"/home/uilian/.conan2/p/emsdkc9782d7aefec5/p/bin/upstream/emscripten/em++"   -fvisibility-inlines-hidden -fexceptions -fPIC -pthread -O3 -Wall -fvisibility=hidden -Wno-inline -m64  -DBOOST_ALL_NO_LIB=1 -DBOOST_COBALT_USE_STD_PMR=1 -DBOOST_REGEX_DYN_LINK=1 -DNDEBUG   -I"." -I"/tmp/tmp.TzQC49uQRm/boost_1_89_0/libs/assert/include" -I"/tmp/tmp.TzQC49uQRm/boost_1_89_0/libs/concept_check/include" -I"/tmp/tmp.TzQC49uQRm/boost_1_89_0/libs/core/include" -I"/tmp/tmp.TzQC49uQRm/boost_1_89_0/libs/predef/include" -I"/tmp/tmp.TzQC49uQRm/boost_1_89_0/libs/preprocessor/include" -I"/tmp/tmp.TzQC49uQRm/boost_1_89_0/libs/regex/include" -I"/tmp/tmp.TzQC49uQRm/boost_1_89_0/libs/static_assert/include" -I"/tmp/tmp.TzQC49uQRm/boost_1_89_0/libs/throw_exception/include" -I"/tmp/tmp.TzQC49uQRm/boost_1_89_0/libs/type_traits/include" -I"libs/config/include"  -c -o "bin.v2/libs/regex/build/emscripten-3.1.72/release/address-model-64/exception-handling-on-js/target-os-none/threading-multi/visibility-hidden/posix_api.o" "/tmp/tmp.TzQC49uQRm/boost_1_89_0/libs/regex/build/../src/posix_api.cpp"
```

And then finally the linker fails with:

```
wasm-ld: error: bin.v2/libs/regex/build/emscripten-3.1.72/release/address-model-64/exception-handling-on-js/target-os-none/threading-multi/visibility-hidden/posix_api.o: must specify -mwasm64 to process wasm64 object files
```

The error occurs because B2 passes `-m64` to the compiler (inherited from clang-linux), which generates wasm64 object files, but doesn't pass the corresponding flag to the linker. 

In order to fix it, I need to pass the Emscripten option `-sMEMORY64=1` as cxxflags and linkflags, so my example script will looks like:

```
./b2 address-model=64 --user-config=${PWD}/user-config.jam cxxflags="-sMEMORY64=1" linkflags="-sMEMORY64=1" toolset=emscripten link=shared install -d2 --debug-configuration --abbreviate-paths 
```

And now I can build boost_regex without errors: [boost-1.89.0-wasm-with-memory64.log](https://github.com/user-attachments/files/24081832/boost-1.89.0-wasm-with-memory64.log)

Plus, now I can see the correct address-model during b2 setup, like `default address-model    : 64-bit [1]`

And after building, I can check the architecture:

```
/home/uilian/.conan2/p/emsdkc9782d7aefec5/p/bin/upstream/bin/llvm-readobj boost_1_89_0/boost_install/lib/libboost_regex.so.1.89.0 --file-headers
File: boost_1_89_0/boost_install/lib/libboost_regex.so.1.89.0
Format: WASM
Arch: wasm64
AddressSize: 64bit
Version: 0x1
```

Reference for memory64: https://emscripten.org/docs/tools_reference/settings_reference.html#memory64

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [x] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [x] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

The Emscripten uses the setting `-sMEMORY64=1` to enable wasm64, rather than the standard `-mwasm64` Clang flag.

This is consistent with how other toolsets in B2 automatically translate `address-model=64` to the appropriate toolset flags (e.g., `-m64` for GCC/Clang, `/MACHINE:X64` for MSVC ...).
