### PR TITLE
[qnx] Fixed build issues including a segfault

### DIFF
--- a/src/tools/qcc.jam
+++ b/src/tools/qcc.jam
@@ -13,6 +13,7 @@ import errors ;
 import feature ;
 import generators ;
 import os ;
+import pch ;
 import property ;
 import regex ;
 import set ;


### PR DESCRIPTION
## Proposed changes

When trying to build boost/1.89.0 using Conan I ran into a series of problems, which this MR tries to address.

> Note: boost/1.81.0 with b2/4.10.1 worked fine

- src/tools/qcc.jam:
  - (imports): added `import pch` to prevent error `error: Invalid property '<pch>on': unknown feature 'pch'.`
  - (compile.c++, compile.c): added missing parameter list to prevent segfault as described in #404
  - (compile.c++): increase template depth from 128 -> 256

Closes #404

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [ ] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [ ] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [ ] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

Not sure if the `import pch` is correct here, since it isn't use afterwards or if the proper change is to change the conan recipe to not append this parameter for a QNX build.

Also a template depth of 256 was just a guess, which worked out fine in my case.
