### PR TITLE
enabling runtime argument checking for free (part 1)

### DIFF
--- a/src/engine/builtins.cpp
+++ b/src/engine/builtins.cpp
@@ -97,7 +97,8 @@
  *  builtin_echo()                - ECHO rule
  *  builtin_exit()                - EXIT rule
  *  builtin_export()              - EXPORT ( MODULE ? : RULES * )
- *  builtin_flags()               - NOCARE, NOTFILE, TEMPORARY rule
+ *  builtin_flags()               - ALWAYS/LEAVES/NOCARE/NOTIME/NOTFILE/NOUPDATE
+ *                                  TEMPORARY/ISFILE/FAIL_EXPECTED/RMOLD rule
  *  builtin_glob()                - GLOB rule
  *  builtin_glob_recursive()      - ???
  *  builtin_hdrmacro()            - ???
@@ -165,9 +166,12 @@ RULE * duplicate_rule( char const * name_, RULE * other )
 
 void load_builtins()
 {
-    duplicate_rule( "Always",
-      bind_builtin( "ALWAYS",
-                    builtin_flags, T_FLAG_TOUCHED, 0 ) );
+    {
+        char const * args[] = { "targets", "*", 0 };
+        duplicate_rule( "Always",
+          bind_builtin( "ALWAYS",
+                        builtin_flags, T_FLAG_TOUCHED, args ) );
+    }
 
     {
         char const * args[] = { "targets1", "*", ":", "targets2", "*", 0 };
@@ -216,9 +220,12 @@ void load_builtins()
                       builtin_rebuilds, 0, args );
     }
 
-    duplicate_rule( "Leaves",
-      bind_builtin( "LEAVES",
-                    builtin_flags, T_FLAG_LEAVES, 0 ) );
+    {
+        char const * args[] = { "targets", "*", 0 };
+        duplicate_rule( "Leaves",
+          bind_builtin( "LEAVES",
+                        builtin_flags, T_FLAG_LEAVES, args ) );
+    }
 
     duplicate_rule( "Match",
       bind_builtin( "MATCH",
@@ -230,39 +237,60 @@ void load_builtins()
                       builtin_split_by_characters, 0, args );
     }
 
-    duplicate_rule( "NoCare",
-      bind_builtin( "NOCARE",
-                    builtin_flags, T_FLAG_NOCARE, 0 ) );
+    {
+        char const * args[] = { "targets", "*", 0 };
+        duplicate_rule( "NoCare",
+          bind_builtin( "NOCARE",
+                        builtin_flags, T_FLAG_NOCARE, args ) );
+    }
 
-    duplicate_rule( "NOTIME",
-    duplicate_rule( "NotFile",
-      bind_builtin( "NOTFILE",
-                    builtin_flags, T_FLAG_NOTFILE, 0 ) ) );
+    {
+        char const * args[] = { "targets", "*", 0 };
+        duplicate_rule( "NOTIME",
+        duplicate_rule( "NotFile",
+          bind_builtin( "NOTFILE",
+                        builtin_flags, T_FLAG_NOTFILE, args ) ) );
+    }
 
-    duplicate_rule( "NoUpdate",
-      bind_builtin( "NOUPDATE",
-                    builtin_flags, T_FLAG_NOUPDATE, 0 ) );
+    {
+        char const * args[] = { "targets", "*", 0 };
+        duplicate_rule( "NoUpdate",
+          bind_builtin( "NOUPDATE",
+                        builtin_flags, T_FLAG_NOUPDATE, args ) );
+    }
 
-    duplicate_rule( "Temporary",
-      bind_builtin( "TEMPORARY",
-                    builtin_flags, T_FLAG_TEMP, 0 ) );
+    {
+        char const * args[] = { "targets", "*", 0 };
+        duplicate_rule( "Temporary",
+          bind_builtin( "TEMPORARY",
+                        builtin_flags, T_FLAG_TEMP, args ) );
+    }
 
-      bind_builtin( "ISFILE",
-                    builtin_flags, T_FLAG_ISFILE, 0 );
+    {
+        char const * args[] = { "targets", "*", 0 };
+          bind_builtin( "ISFILE",
+                        builtin_flags, T_FLAG_ISFILE, args );
+    }
 
     duplicate_rule( "HdrMacro",
       bind_builtin( "HDRMACRO",
                     builtin_hdrmacro, 0, 0 ) );
 
-    /* FAIL_EXPECTED is used to indicate that the result of a target build
-     * action should be inverted (ok <=> fail) this can be useful when
-     * performing test runs from Jamfiles.
-     */
-    bind_builtin( "FAIL_EXPECTED",
-                  builtin_flags, T_FLAG_FAIL_EXPECTED, 0 );
+    {
+        /* FAIL_EXPECTED is used to indicate that the result of a target build
+         * action should be inverted (ok <=> fail) this can be useful when
+         * performing test runs from Jamfiles.
+         */
+        char const * args[] = { "targets", "*", 0 };
+        bind_builtin( "FAIL_EXPECTED",
+                      builtin_flags, T_FLAG_FAIL_EXPECTED, args );
+    }
 
-    bind_builtin( "RMOLD",
-                  builtin_flags, T_FLAG_RMOLD, 0 );
+    {
+        char const * args[] = { "targets", "*", 0 };
+        bind_builtin( "RMOLD",
+                      builtin_flags, T_FLAG_RMOLD, args );
+    }
 
     {
         char const * args[] = { "targets", "*", 0 };


### PR DESCRIPTION
```JAM
ECHO [ DEPENDS  a : b : c ] ;
```

actual behaviour
```shell
# b2

...found 1 target...
```

expected behaviour
```shell
# b2
jamfile.jam:1: in modules.load
*** argument error
* rule DEPENDS ( targets1 * : targets2 * )
* called with: ( a : b : c )
* extra argument c
(builtin):see definition of rule 'DEPENDS' being called
/home/pax/.local/share/b2/src/build/project.jam:586: in load-jamfile
/home/pax/.local/share/b2/src/build/project.jam:84: in load
/home/pax/.local/share/b2/src/build/project.jam:241: in project.find
/home/pax/.local/share/b2/src/build-system.jam:639: in module scope
```

the same goes for INCLUDES
