### PR TITLE
__init_features|generators__.jam regexp review

### DIFF
--- a/src/tools/features/__init_features__.jam
+++ b/src/tools/features/__init_features__.jam
@@ -12,7 +12,7 @@ import os path modules ;
 .this-module's-file = [ modules.binding $(__name__) ] ;
 .this-module's-dir = [ path.parent [ path.make $(.this-module's-file) ] ] ;
 .to-load-jamfiles =  [ path.glob $(.this-module's-dir) : *-$(key).jam ] ;
-.to-load-modules = [ MATCH ^(.*)\.jam$ : $(.to-load-jamfiles) ] ;
+.to-load-modules = [ MATCH ^(.*)\\.jam$ : $(.to-load-jamfiles) ] ;
 
 # A loop over all matched modules in this directory
 for local m in $(.to-load-modules)

--- a/src/tools/generators/__init_generators__.jam
+++ b/src/tools/generators/__init_generators__.jam
@@ -12,7 +12,7 @@ import os path modules ;
 .this-module's-file = [ modules.binding $(__name__) ] ;
 .this-module's-dir = [ path.parent [ path.make $(.this-module's-file) ] ] ;
 .to-load-jamfiles =  [ path.glob $(.this-module's-dir) : *-$(key).jam ] ;
-.to-load-modules = [ MATCH ^(.*)\.jam$ : $(.to-load-jamfiles) ] ;
+.to-load-modules = [ MATCH ^(.*)\\.jam$ : $(.to-load-jamfiles) ] ;
 
 # A loop over all matched modules in this directory
 for local m in $(.to-load-modules)


### PR DESCRIPTION
Luckily, it's not common to find files with the jam suffix (without the dot) around...
If there were these scripts they would try to load them.
toward fix #488