### PR TITLE
regerror must exit with error

### DIFF
--- a/src/engine/builtins.cpp
+++ b/src/engine/builtins.cpp
@@ -992,6 +992,10 @@ LIST * builtin_glob_recursive( FRAME * frame, int flags )
 }
 
 
+/*
+ * builtin_subst() - SUBST rule, regexp replacing
+ */
+
 LIST * builtin_subst( FRAME * frame, int flags )
 {
     LIST * result = L0;
@@ -1002,9 +1006,14 @@ LIST * builtin_subst( FRAME * frame, int flags )
     if ( iter != end && list_next( iter ) != end && list_next( list_next( iter )
         ) != end )
     {
-        char const * const source = object_str( list_item( iter ) );
-        b2::regex::program re( list_item( list_next( iter ) )->str() );
+        b2::regex::program re;
+        {
+            // compilation errors print a nice error message and exit
+            b2::regex::frame_ctx ctx(frame);
+            re.reset( list_item( list_next( iter ) )->str() );
+        }
 
+        char const * const source = object_str( list_item( iter ) );
         if ( auto re_i = re.search(source) )
         {
             LISTITER subst = list_next( iter );

--- a/src/engine/regexp.cpp
+++ b/src/engine/regexp.cpp
@@ -85,17 +85,17 @@ namespace b2 { namespace regex {
 thread_local FRAME * frame = nullptr;
 
 /*
- * Handles any errors that occur while compiling a regex.
+ * Handles any error that occur while compiling a regex.
  * Largely inspired to argument_error() from function.cpp. An alternative,
- * more structured method of issuing errors would be appropriate.
+ * more structured method of issuing errors would be appropriate,
+ * using stderr would be better too.
  */
 void regerror(char const * s)
 {
 	// frame comes from the thread_local variable b2::regex::frame
 	if (frame == nullptr)
 	{
-		// NOTE: "legacy" behaviour, but should exit here
-		printf("regexp error: %s\n", s);
+		out_printf("regexp error: %s\n", s);
 	}
 	else
 	{
@@ -106,8 +106,8 @@ void regerror(char const * s)
 		out_printf( " )\n* %s\n", s );
 		print_source_line( frame );
 		backtrace( frame->prev );
-		b2::clean_exit( EXITBAD );
 	}
+	b2::clean_exit( EXITBAD );
 }
 
 /*


### PR DESCRIPTION
As explained in #489 error handling still needed fixing.

With this PR we are sure that there cannot be any regexps that were not compiled due to some error and therefore will not work without anyone noticing.

I also added the new error message to the SUBST builtin rule, which I discovered is not documented...