### PR TITLE
partially revert of #500 build/build-request.jam

### DIFF
--- a/src/build/build-request.jam
+++ b/src/build/build-request.jam
@@ -190,7 +190,7 @@ rule from-command-line ( command-line * )
             # Build request spec either has "=" in it or completely consists of
             # implicit feature values.
             local fs = feature-space ;
-            if [ MATCH "(=)" : $(e) ]
+            if [ MATCH "(.+=.*)" : $(e) ]
                 || [ looks-like-implicit-value $(e:D=) : $(feature-space) ]
             {
                 properties += $(e) ;


### PR DESCRIPTION
I am getting older, I was compiling b2 with `--debug` to speed up the compilation... but of course the tests are the ones that slow it down