### PR TITLE
simpler error format and more consistent backtrace

### DIFF
--- a/src/engine/function.cpp
+++ b/src/engine/function.cpp
@@ -3379,7 +3379,6 @@ int32_t is_type_name( char const * s )
 static void argument_error( char const * message, FUNCTION * procedure,
     FRAME * frame, OBJECT * arg )
 {
-    extern void print_source_line( FRAME * );
     LOL * actual = frame->args;
     backtrace_line( frame->prev );
     out_printf( "*** argument error\n* rule %s ( ", frame->rulename );
@@ -3388,9 +3387,7 @@ static void argument_error( char const * message, FUNCTION * procedure,
     out_printf( " )\n* called with: ( " );
     lol_print( actual );
     out_printf( " )\n* %s %s\n", message, arg ? object_str ( arg ) : "" );
-    function_location( procedure, &frame->file, &frame->line );
-    print_source_line( frame );
-    out_printf( "see definition of rule '%s' being called\n", frame->rulename );
+    //function_location( procedure, &frame->file, &frame->line );
     backtrace( frame->prev );
     b2::clean_exit( EXITBAD );
 }

--- a/src/engine/regexp.cpp
+++ b/src/engine/regexp.cpp
@@ -99,13 +99,19 @@ void regerror(char const * s)
 	}
 	else
 	{
-		backtrace_line( frame->prev );
+		bool has_prev = frame->prev != nullptr;
+		if (has_prev) backtrace_line( frame->prev );
+		else
+		{
+			// TODO
+			// if (frame->file) ...
+			// if (frame->line != -1) ...
+		}
 		out_printf( "*** regexp error\n* rule %s", frame->rulename );
 		out_printf( " called with: ( " );
 		lol_print( frame->args );
 		out_printf( " )\n* %s\n", s );
-		print_source_line( frame );
-		backtrace( frame->prev );
+		if (has_prev) backtrace( frame->prev );
 	}
 	b2::clean_exit( EXITBAD );
 }

--- a/test/core_source_line_tracking.py
+++ b/test/core_source_line_tracking.py
@@ -31,8 +31,12 @@ def test_error_missing_argument(eof):
 rule f ( param ) { }
 f ;%s""" % __trailing_newline(eof))
     t.run_build_system(["-ffile.jam"], status=1)
-    t.expect_output_lines("file.jam:2: in module scope")
-    t.expect_output_lines("file.jam:1:see definition of rule 'f' being called")
+    t.expect_output_lines("""\
+file.jam:2: in module scope
+*** argument error
+* rule f ( param )
+* called with: (  )
+* missing argument param""")
     t.cleanup()
 
 

--- a/test/core_typecheck.py
+++ b/test/core_typecheck.py
@@ -8,7 +8,7 @@
 
 import BoostBuild
 
-t = BoostBuild.Tester(["-ffile.jam"], pass_toolset=0)
+t = BoostBuild.Tester(["-ffile.jam"], pass_toolset=False)
 
 t.write("file.jam", """
 module .typecheck
@@ -41,7 +41,6 @@ file.jam:18: in module scope
 * rule do ( [path] a )
 * called with: ( a/b/c )
 * true a
-file.jam:16:see definition of rule 'do' being called
 """)
 
 t.cleanup()


### PR DESCRIPTION
output, e.g:
```
Jamroot:2: in modules.load
*** argument error
* rule NATIVE_RULE ( module : rule )
* called with: ( a : b : c )
* extra argument c
/home/pax/.local/share/b2/src/build/project.jam:586: in load-jamfile
...
```
I'm trying to clean up some of the errors, before making any other changes.