### PR TITLE
documentation maintenance

### DIFF
--- a/doc/src/bjam.adoc
+++ b/doc/src/bjam.adoc
@@ -1357,7 +1357,7 @@ _value_ is specific to either variable or generated file expansion.
 
 On VMS, `$(var:P)` is the parent directory of `$(var:D)`.
 
-`:<=value`::
+`:\<=value`::
 After evaluating the expansion of the variable prefixes the given _value_
 to the elements of the expanded expression values.
 

--- a/doc/src/property-set.adoc
+++ b/doc/src/property-set.adoc
@@ -16,9 +16,9 @@ class property-set {
 }
 ----
 
-There is 1<->1 correspondence between identity and value. No two
+There is +1<->1+ correspondence between identity and value. No two
 instances of the class are equal. To maintain this property, the
-'property-set.create' rule should be used to create new instances.
+`property-set.create` rule should be used to create new instances.
 Instances are immutable.
 
 --

--- a/doc/src/reference.adoc
+++ b/doc/src/reference.adoc
@@ -949,7 +949,7 @@ will create the files for `a` in `bin/subdir/gcc-4.6.1/debug`
 
 A _feature_ is a normalized (toolset-independent) aspect of a build
 configuration, such as whether inlining is enabled. Feature names may
-not contain the '`>`' character.
+not contain the ‘`>`’ character.
 
 Each feature in a build configuration has one or more associated
 __value__s. Feature values for non-free features may not contain the

--- a/src/build/project.jam
+++ b/src/build/project.jam
@@ -764,7 +764,7 @@ rule initialize (
             local cfgs = project site test user all ;
             if ! $(module-name) in $(cfgs)-config
             {
-                # This is a standalone project with known location. Set its
+                # This is a standalone project with unknown location. Set its
                 # source location so it can declare targets. This is needed so
                 # you can put a .jam file with your sources and use it via
                 # 'using'. Standard modules (in the 'tools' subdir) may not

--- a/src/engine/mod_jam_errors.h
+++ b/src/engine/mod_jam_errors.h
@@ -140,7 +140,7 @@ void warning(const lists & rest, bind::context_ref_ context_ref);
 
 ====
 [horizontal]
-Jam:: `rule lol->list ( * )`
+Jam:: `rule lol\->list ( * )`
 {CPP}:: `list_ref lol_to_list(const lists & rest);`
 ====
 

--- a/src/engine/mod_set.h
+++ b/src/engine/mod_set.h
@@ -33,8 +33,8 @@ Set class contains unique values.
 ====
 [horizontal]
 Jam:: `rule add ( elements * )`
-{CPP}:: `void b2::set::add(b2::list_cref elements);`, `void b2::set::add(const
-b2::set & elements);`
+{CPP}:: `void b2::set::add(b2::list_cref elements);`
+{CPP}:: `void b2::set::add(const b2::set & elements);`
 ====
 
 Add the `elements` to the set.
@@ -79,7 +79,7 @@ Jam:: `rule intersection ( set1 * : set2 * )`
 b2::list_cref set2);`
 ====
 
-Removes all the items appearing in both `set1` & `set2`.
+Returns all the items appearing in both `set1` & `set2`.
 
 === `b2::set::equal`
 

--- a/src/engine/rules.h
+++ b/src/engine/rules.h
@@ -175,10 +175,10 @@ struct _target
 #define T_FLAG_NOUPDATE 0x0020 /* NOUPDATE applied */
 #define T_FLAG_VISITED 0x0040 /* CWM: Used in debugging */
 
-/* This flag has been added to support a new built-in rule named "RMBAD". It is
+/* This flag has been added to support a new built-in rule named "RMOLD". It is
  * used to force removal of outdated targets whose dependencies fail to build.
  */
-#define T_FLAG_RMOLD 0x0080 /* RMBAD applied */
+#define T_FLAG_RMOLD 0x0080 /* RMOLD applied */
 
 /* This flag was added to support a new built-in rule named "FAIL_EXPECTED" used
  * to indicate that the result of running a given action should be inverted,


### PR DESCRIPTION
escaping of asciidoctor arrow in §6.5.3 errors
fixed formatting, fixed description of b2::set::intersection in §6.5.5 set
escaping of asciidoctor arrow, fixed formatting in §6.6.6 Class property-set
fixed formatting in §6.8.1 Features and properties
escaping of asciidoctor arrow in §12.2.6 Variable Expansion
fixed comment in build/project.jam
fixed comment in rules.h
