### PR TITLE
Fix crash in var_defines when define string is empty

### DIFF
--- a/src/engine/variable.cpp
+++ b/src/engine/variable.cpp
@@ -80,10 +80,11 @@ void var_defines(struct module_t * module, const char * const * e, int preproces
 		::b2::string_view def(*e);
 		::b2::string_view var = def;
 		::b2::string_view val;
-		if (auto eq = def.find('='); eq != ::b2::string_view::npos)
+		auto eq = def.find('=');
+		if (eq != ::b2::string_view::npos)
 		{
 			var = ::b2::string_view(def.begin(), eq);
-			val = ::b2::string_view(def.begin() + var.size() + 1);
+			val = ::b2::string_view(def.begin() + eq + 1);
 		}
 		b2::jam::variable jam_var { module,
 			std::string { var.begin(), var.end() }.c_str() };


### PR DESCRIPTION
b2 aborts in var_defines on empty define

## Proposed changes

Skip empty definition strings in var_defines() to avoid startup abort (std::length_error) when the built-in define list contains "".
Fixed the bug described in: #534 

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [x] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I added necessary documentation (if appropriate)
