### PR TITLE
fixed test/default_toolset.py

### DIFF
--- a/src/build-system.jam
+++ b/src/build-system.jam
@@ -655,17 +655,13 @@ local rule should-clean-project ( project )
         else
         {
             default-toolset = gcc ;
-            if [ os.name ] = NT
+            switch [ os.name ]
             {
-                default-toolset = msvc ;
-            }
-            else if [ os.name ] = VMS
-            {
-                default-toolset = vmsdecc ;
-            }
-            else if [ os.name ] = MACOSX || [ os.name ] = FREEBSD || [ os.name ] = OPENBSD
-            {
-                default-toolset = clang ;
+                case FREEBSD : default-toolset = clang ;
+                case MACOSX  : default-toolset = clang ;
+                case NT      : default-toolset = msvc ;
+                case OPENBSD : default-toolset = clang ;
+                case VMS     : default-toolset = vmsdecc ;
             }
         }
 


### PR DESCRIPTION
* removed `test_default_toolset_requirements`<sup>[1]</sup>
* removed `test_conditions_on_default_toolset`<sup>[2]</sup>
* added `test_default_toolset` for testing of `build-system.set-default-toolset` rule
* optimized default-toolset selection in `build-system.jam`

> [!NOTE]
> Do we really need `test/results-python.txt`?

## <sup>[1]</sup>
`test_default_toolset_requirements` has the following problems:
* Improperly uses `feature.get-values`, since it is not intended to process conditionals, and even if it were, it would not be correct to write one like the ones used in the test, i.e.: `<description>toolset-requirement:<description>conditioned-requirement` considering that "_Free features can never be used in conditionals_" as I found written in a comment in `build/feature.jam` (who knows if it's true... the test could have also avoided creating the `description` feature and used the default `define`.)
* The `buildRule` used in the `notfile testTarget` target cannot see the properties set on the toolset with the `toolset.add-requirements` because the Jamfile is loaded before the `using` of the default toolset is executed, i.e., before the `toolset.add-requirements` is called.

## <sup>[2]</sup>
The `test_conditions_on_default_toolset` is affected by the same issues as the `test_default_toolset_requirements` above.