### PR TITLE
failure to clean of tests package.py and scanner_causing_rebuilds.py fixed

### DIFF
--- a/test/package.py
+++ b/test/package.py
@@ -194,6 +194,7 @@ def test_multiple():
     t.expect_addition("p/yyy/lib/b.dll")
     t.expect_addition("p/yyy/lib/b.lib")
     t.expect_addition("p/yyy/include/a.h")
+    t.cleanup()
 
 def test_paths():
     t = BoostBuild.Tester(pass_toolset=False)

--- a/test/pch.py
+++ b/test/pch.py
@@ -7,7 +7,6 @@
 # https://www.bfgroup.xyz/b2/LICENSE.txt)
 
 import BoostBuild
-from time import sleep
 
 
 t = BoostBuild.Tester()

--- a/test/scanner_causing_rebuilds.py
+++ b/test/scanner_causing_rebuilds.py
@@ -130,3 +130,4 @@ t.run_build_system()
 # should not cause any files to be affected.
 t.run_build_system()
 t.expect_nothing_more()
+t.cleanup()


### PR DESCRIPTION
unnecessary import removed from pch.py