### PR TITLE
outerr C++ module update

### DIFF
--- a/doc/src/history.adoc
+++ b/doc/src/history.adoc
@@ -6,6 +6,7 @@
 * *New*: Argument lists description provided for all built-in rules,
   GLOB-RECURSIVELY has become an alias of GLOB_RECURSIVELY.
 * *New*: Added test for regular expressions with MATCH builtin rule.
+* *New*: Improved control of source module by IMPORT and EXPORT rules.
   -- _Paolo Pastori_
 * Fix Jam/{CPP} bind definitions of 4 or more values in a single
   declared argument not actually adding all the definitions.

--- a/doc/src/history.adoc
+++ b/doc/src/history.adoc
@@ -3,10 +3,11 @@
 
 == Version 5.5.0
 
-* *New*: Argument lists description provided for all built-in rules,
+* *New*: Argument lists description provided for all builtin rules,
   GLOB-RECURSIVELY has become an alias of GLOB_RECURSIVELY.
 * *New*: Added test for regular expressions with MATCH builtin rule.
-* *New*: Improved control of source module by IMPORT and EXPORT rules.
+* *New*: Improved control of source module by IMPORT, EXPORT, and
+  RULENAMES builtin rules.
   -- _Paolo Pastori_
 * Fix Jam/{CPP} bind definitions of 4 or more values in a single
   declared argument not actually adding all the definitions.

--- a/src/engine/builtins.cpp
+++ b/src/engine/builtins.cpp
@@ -1136,32 +1136,53 @@ LIST * builtin_split_by_characters( FRAME * frame, int flags )
 
 
 /*
- * builtin_rulenames() - RULENAMES ( MODULE ? )
- *
- * Returns a list of the non-local rule names in the given MODULE. If MODULE is
- * not supplied, returns the list of rule names in the global module.
+ * Search for an optional module, when no name is supplied
+ * return the root module. When the supplied name is not found
+ * emit an error (and exit) or a warning (and return the root module)
+ * according to the value of miss_is_error.
  */
-
-static void add_rule_name( void * r_, void * result_ )
+module_t * try_bind_module(LIST * module_list, FRAME * frame, bool miss_is_error)
 {
-    RULE * const r = (RULE *)r_;
-    LIST * * const result = (LIST * *)result_;
-    if ( r->exported )
-        *result = list_push_back( *result, object_copy( r->name ) );
+    OBJECT * mod_name = ( list_empty( module_list )
+        ? nullptr : list_front( module_list ) );
+    module_t * mod = nullptr;
+    if ( mod_name )
+    {
+        mod = find_module( mod_name );
+        if ( ! mod )
+        {
+            b2::list_ref msgs;
+
+            msgs.push_back(
+                b2::rule_and_args_to_string( frame ) );
+            msgs.push_back(
+                std::string("module \"") + mod_name->str() + "\" not found"
+                + (miss_is_error ? "." : ", using root module.") );
+
+            if ( miss_is_error ) b2::out_error( *msgs, frame );
+            else b2::out_warning( *msgs, frame );
+        }
+    }
+    if ( ! mod ) mod = root_module();
+    return mod;
 }
 
 
+/*
+ * builtin_rulenames() - RULENAMES ( MODULE ? )
+ *
+ * Returns a list of the non-local rule names in the given MODULE. If MODULE
+ * is not supplied, returns the list of rule names in the root module.
+ * If MODULE is not found, an error is issued.
+ */
+
 LIST * builtin_rulenames( FRAME * frame, int flags )
 {
-    LIST * arg0 = lol_get( frame->args, 0 );
-    LIST * result = L0;
-    module_t * const source_module = bindmodule( list_empty( arg0 )
-        ? 0
-        : list_front( arg0 ) );
+    LIST * module_list = lol_get( frame->args, 0 );
+    module_t * module = try_bind_module( module_list, frame,
+            true /* emit an error on missing module */ );
 
-    if ( source_module->rules )
-        hashenumerate( source_module->rules, add_rule_name, &result );
-    return result;
+    return module_rules( module );
 }
 
 
@@ -1212,37 +1233,6 @@ LIST * builtin_delete_module( FRAME * frame, int flags )
     return L0;
 }
 
-/*
- * Search for an optional module, when no name is supplied
- * return the root module. When the supplied name is not found
- * emit an error (and exit) or a warning (and return the root module)
- * according to the value of miss_is_error.
- */
-module_t * try_bind_module(LIST * module_list, FRAME * frame, bool miss_is_error)
-{
-    OBJECT * mod_name = ( list_empty( module_list )
-        ? nullptr : list_front( module_list ) );
-    module_t * mod = nullptr;
-    if ( mod_name )
-    {
-        mod = find_module( mod_name );
-        if ( ! mod )
-        {
-            b2::list_ref msgs;
-
-            msgs.push_back(
-                b2::rule_and_args_to_string( frame ) );
-            msgs.push_back(
-                std::string("module \"") + mod_name->str() + "\" not found"
-                + (miss_is_error ? "." : ", using root module.") );
-
-            if ( miss_is_error ) b2::out_error( *msgs, frame );
-            else b2::out_warning( *msgs, frame );
-        }
-    }
-    if ( ! mod ) mod = root_module();
-    return mod;
-}
 
 /*
  * builtin_import() - IMPORT rule

--- a/src/engine/builtins.cpp
+++ b/src/engine/builtins.cpp
@@ -1234,7 +1234,7 @@ module_t * try_bind_module(LIST * module_list, FRAME * frame, bool miss_is_error
                 b2::rule_and_args_to_string( frame ) );
             msgs.push_back(
                 std::string("module \"") + mod_name->str() + "\" not found"
-                + (miss_is_error ? "." : ", using global module.") );
+                + (miss_is_error ? "." : ", using root module.") );
 
             if ( miss_is_error ) b2::out_error( *msgs, frame );
             else b2::out_warning( *msgs, frame );
@@ -1258,7 +1258,7 @@ module_t * try_bind_module(LIST * module_list, FRAME * frame, bool miss_is_error
  *
  * Imports rules from the SOURCE_MODULE into the TARGET_MODULE as local rules.
  * If either SOURCE_MODULE or TARGET_MODULE is not supplied, it refers to the
- * global module. SOURCE_RULES specifies which rules from the SOURCE_MODULE to
+ * root module. SOURCE_RULES specifies which rules from the SOURCE_MODULE to
  * import; TARGET_RULES specifies the names to give those rules in
  * TARGET_MODULE. If SOURCE_RULES contains a name that does not correspond to
  * a rule in SOURCE_MODULE, or if it contains a different number of items than
@@ -1335,7 +1335,7 @@ LIST * builtin_import( FRAME * frame, int flags )
  * builtin_export() - EXPORT ( MODULE ? : RULES * )
  *
  * The EXPORT rule marks RULES from the MODULE as non-local (and thus
- * exportable). If MODULE is not supplied, it refers to the global module.
+ * exportable). If MODULE is not supplied, it refers to the root module.
  * If MODULE is not found, or an element of RULES does not name a rule
  * in MODULE, an error is issued.
  */

--- a/src/engine/builtins.cpp
+++ b/src/engine/builtins.cpp
@@ -18,6 +18,7 @@
 #include "make.h"
 #include "md5.h"
 #include "native.h"
+#include "outerr.h"
 #include "parse.h"
 #include "pathsys.h"
 #include "regexp.h"
@@ -29,6 +30,7 @@
 #include "output.h"
 
 #include <string>
+#include <type_traits>
 
 #include <assert.h>
 #include <ctype.h>
@@ -79,13 +81,20 @@
 # define WEXITSTATUS(w)(w)
 #endif
 
+namespace b2 {
+template<typename R,
+         typename = typename std::enable_if<std::is_pointer<R>::value>::type>
+R find_hash(struct hash * ht, OBJECT * obj)
+{
+    return reinterpret_cast<R>( ht ? hash_find(ht, obj) : nullptr );
+}
+} // namespace b2
+
 /*
  * builtins.c - builtin jam rules
  *
  * External routines:
  *  load_builtins()               - define builtin rules
- *  unknown_rule()                - reports an unknown rule occurrence to the
- *                                  user and exits
  *
  * Internal routines:
  *  append_if_exists()            - if file exists, append it to the list
@@ -123,10 +132,6 @@
 #endif
 
 int glob( char const * s, char const * c );
-
-void backtrace        ( FRAME * );
-void backtrace_line   ( FRAME * );
-void print_source_line( FRAME * );
 
 
 RULE * bind_builtin( char const * name_, LIST * (* f)( FRAME *, int flags ),
@@ -446,8 +451,8 @@ void load_builtins()
 
     {
         char const * args[] = { "command", ":", "*", 0 };
-        duplicate_rule( "SHELL",
-          bind_builtin( "COMMAND",
+        duplicate_rule( "COMMAND",
+          bind_builtin( "SHELL",
                         builtin_shell, 0, args ) );
     }
 
@@ -1207,28 +1212,37 @@ LIST * builtin_delete_module( FRAME * frame, int flags )
     return L0;
 }
 
-
 /*
- * unknown_rule() - reports an unknown rule occurrence to the user and exits
+ * Search for an optional module, when no name is supplied
+ * return the root module. When the supplied name is not found
+ * emit an error (and exit) or a warning (and return the root module)
+ * according to the value of miss_is_error.
  */
-
-void unknown_rule( FRAME * frame, char const * key, module_t * module,
-    OBJECT * rule_name )
+module_t * try_bind_module(LIST * module_list, FRAME * frame, bool miss_is_error)
 {
-    backtrace_line( frame->prev );
-    if ( key )
-        out_printf("%s error", key);
-    else
-        out_printf("ERROR");
-    out_printf( ": rule \"%s\" unknown in ", object_str( rule_name ) );
-    if ( module->name )
-        out_printf( "module \"%s\".\n", object_str( module->name ) );
-    else
-        out_printf( "root module.\n" );
-    backtrace( frame->prev );
-    b2::clean_exit( EXITBAD );
-}
+    OBJECT * mod_name = ( list_empty( module_list )
+        ? nullptr : list_front( module_list ) );
+    module_t * mod = nullptr;
+    if ( mod_name )
+    {
+        mod = find_module( mod_name );
+        if ( ! mod )
+        {
+            b2::list_ref msgs;
 
+            msgs.push_back(
+                b2::rule_and_args_to_string( frame ) );
+            msgs.push_back(
+                std::string("module \"") + mod_name->str() + "\" not found"
+                + (miss_is_error ? "." : ", using global module.") );
+
+            if ( miss_is_error ) b2::out_error( *msgs, frame );
+            else b2::out_warning( *msgs, frame );
+        }
+    }
+    if ( ! mod ) mod = root_module();
+    return mod;
+}
 
 /*
  * builtin_import() - IMPORT rule
@@ -1264,9 +1278,8 @@ LIST * builtin_import( FRAME * frame, int flags )
     module_t * target_module = bindmodule( list_empty( target_module_list )
         ? 0
         : list_front( target_module_list ) );
-    module_t * source_module = bindmodule( list_empty( source_module_list )
-        ? 0
-        : list_front( source_module_list ) );
+    module_t * source_module = try_bind_module( source_module_list, frame,
+            false /* emit a warning on missing module */ );
 
     LISTITER source_iter = list_begin( source_rules );
     LISTITER const source_end = list_end( source_rules );
@@ -1278,17 +1291,13 @@ LIST * builtin_import( FRAME * frame, int flags )
           source_iter = list_next( source_iter ),
           target_iter = list_next( target_iter ) )
     {
-        RULE * r = nullptr;
-        RULE * imported = nullptr;
-
-        if ( !source_module->rules || !(r = (RULE *)hash_find(
-            source_module->rules, list_item( source_iter ) ) ) )
+        RULE * r = b2::find_hash<RULE*>( source_module->rules, list_item( source_iter ) );
+        if ( !r )
         {
-            unknown_rule( frame, "IMPORT", source_module, list_item( source_iter
-                ) );
+            unknown_rule_error( frame, source_module, list_item( source_iter ) );
         }
 
-        imported = import_rule( r, target_module, list_item( target_iter ) );
+        RULE * imported = import_rule( r, target_module, list_item( target_iter ) );
         if ( !list_empty( localize ) )
             rule_localize( imported, target_module );
         /* This rule is really part of some other module. Just refer to it here,
@@ -1299,16 +1308,23 @@ LIST * builtin_import( FRAME * frame, int flags )
 
     if ( source_iter != source_end || target_iter != target_end )
     {
-        backtrace_line( frame->prev );
-        out_printf( "import error: length of source and target rule name lists "
-            "don't match!\n" );
-        out_printf( "    source: " );
-        list_print( source_rules );
-        out_printf( "\n    target: " );
-        list_print( target_rules );
-        out_printf( "\n" );
-        backtrace( frame->prev );
-        b2::clean_exit( EXITBAD );
+        b2::list_ref msgs;
+
+        msgs.push_back( b2::rule_and_args_to_string( frame ) );
+
+        msgs.push_back( "source and target rule name lists don't match" );
+
+        std::string rlst = "source:";
+        for ( auto el : b2::list_cref(source_rules) )
+            rlst += std::string(" ") + el->str();
+        msgs.push_back( rlst );
+
+        rlst = "target:";
+        for ( auto el : b2::list_cref(target_rules) )
+            rlst += std::string(" ") + el->str();
+        msgs.push_back( rlst );
+
+        b2::out_error( *msgs, frame );
     }
 
     return L0;
@@ -1318,27 +1334,27 @@ LIST * builtin_import( FRAME * frame, int flags )
 /*
  * builtin_export() - EXPORT ( MODULE ? : RULES * )
  *
- * The EXPORT rule marks RULES from the SOURCE_MODULE as non-local (and thus
- * exportable). If an element of RULES does not name a rule in MODULE, an error
- * is issued.
+ * The EXPORT rule marks RULES from the MODULE as non-local (and thus
+ * exportable). If MODULE is not supplied, it refers to the global module.
+ * If MODULE is not found, or an element of RULES does not name a rule
+ * in MODULE, an error is issued.
  */
 
 LIST * builtin_export( FRAME * frame, int flags )
 {
     LIST * const module_list = lol_get( frame->args, 0 );
     LIST * const rules = lol_get( frame->args, 1 );
-    module_t * const m = bindmodule( list_empty( module_list ) ? 0 : list_front(
-        module_list ) );
+    module_t * const m = try_bind_module( module_list, frame,
+            true /* emit an error on missing module */ );
 
     LISTITER iter = list_begin( rules );
     LISTITER const end = list_end( rules );
     for ( ; iter != end; iter = list_next( iter ) )
     {
-        RULE * r = nullptr;
-        if ( !m->rules || !( r = (RULE *)hash_find( m->rules, list_item( iter )
-            ) ) )
+        RULE * r = b2::find_hash<RULE*>( m->rules, list_item( iter ) );
+        if ( !r )
         {
-            unknown_rule( frame, "EXPORT", m, list_item( iter ) );
+            unknown_rule_error( frame, m, list_item( iter ) );
         }
         r->exported = 1;
     }
@@ -1353,7 +1369,7 @@ LIST * builtin_export( FRAME * frame, int flags )
  * output or an error backtrace.
  */
 
-static void get_source_line( FRAME * frame, char const * * file, int * line )
+void get_source_line( FRAME * frame, char const * * file, int * line )
 {
     if ( frame->file )
     {
@@ -1367,52 +1383,6 @@ static void get_source_line( FRAME * frame, char const * * file, int * line )
         *file = "(builtin)";
         *line = -1;
     }
-}
-
-
-void print_source_line( FRAME * frame )
-{
-    char const * file;
-    int line;
-    get_source_line( frame, &file, &line );
-    if ( line > 0 )
-        out_printf( "%s:%d:", file, line );
-    else if ( line == 0 )
-        out_printf( "%s:", file );
-    else
-        out_printf( "(builtin):" );
-}
-
-
-/*
- * backtrace_line() - print a single line of error backtrace for the given
- * frame.
- */
-
-void backtrace_line( FRAME * frame )
-{
-    if ( frame == 0 )
-    {
-        out_printf( "(no frame):" );
-    }
-    else
-    {
-        print_source_line( frame );
-        out_printf( " in %s\n", frame->rulename );
-    }
-}
-
-
-/*
- * backtrace() - Print the entire backtrace from the given frame to the Jambase
- * which invoked it.
- */
-
-void backtrace( FRAME * frame )
-{
-    if ( !frame ) return;
-    while ( ( frame = frame->prev ) )
-        backtrace_line( frame );
 }
 
 
@@ -1658,19 +1628,23 @@ LIST * builtin_native_rule( FRAME * frame, int flags )
 
     module_t * module = bindmodule( list_front( module_name ) );
 
-    native_rule_t * np;
-    if ( module->native_rules && (np = (native_rule_t *)hash_find(
-        module->native_rules, list_front( rule_name ) ) ) )
+    native_rule_t * np = b2::find_hash<native_rule_t*>(
+            module->native_rules, list_front( rule_name ) );
+    if ( np )
     {
         new_rule_body( module, np->name, np->procedure, 1 );
     }
     else
     {
-        backtrace_line( frame->prev );
-        out_printf( "error: no native rule \"%s\" defined in module \"%s.\"\n",
-            object_str( list_front( rule_name ) ), object_str( module->name ) );
-        backtrace( frame->prev );
-        b2::clean_exit( EXITBAD );
+        b2::list_ref msgs;
+
+        msgs.push_back( b2::rule_and_args_to_string( frame ) );
+
+        msgs.push_back(
+            std::string("no native rule \"") + list_front( rule_name )->str()
+            + "\" defined in module \"" + module->name->str() + "\"." );
+
+        b2::out_error( *msgs, frame );
     }
     return L0;
 }
@@ -1684,9 +1658,9 @@ LIST * builtin_has_native_rule( FRAME * frame, int flags )
 
     module_t * module = bindmodule( list_front( module_name ) );
 
-    native_rule_t * np;
-    if ( module->native_rules && (np = (native_rule_t *)hash_find(
-        module->native_rules, list_front( rule_name ) ) ) )
+    native_rule_t * np = b2::find_hash<native_rule_t*>(
+            module->native_rules, list_front( rule_name ) );
+    if ( np )
     {
         int expected_version = atoi( object_str( list_front( version ) ) );
         if ( np->version == expected_version )

--- a/src/engine/builtins.h
+++ b/src/engine/builtins.h
@@ -64,7 +64,6 @@ LIST *builtin_readlink( FRAME * frame, int flags );
 LIST *builtin_glob_archive( FRAME * frame, int flags );
 LIST *builtin_debug_print_helper( FRAME * frame, int flags );
 
-void backtrace( FRAME *frame );
 extern int last_update_now_status;
 
 #endif

--- a/src/engine/compile.cpp
+++ b/src/engine/compile.cpp
@@ -32,6 +32,7 @@
 #include "hash.h"
 #include "make.h"
 #include "modules.h"
+#include "outerr.h"
 #include "parse.h"
 #include "rules.h"
 #include "search.h"
@@ -49,12 +50,6 @@
 
 
 static void debug_compile( int which, char const * s, FRAME * );
-
-/* Internal functions from builtins.c */
-void backtrace( FRAME * );
-void backtrace_line( FRAME * );
-void print_source_line( FRAME * );
-void unknown_rule( FRAME *, char const * key, module_t *, OBJECT * rule_name );
 
 
 /*
@@ -105,7 +100,7 @@ LIST * evaluate_rule( RULE * rule, OBJECT * rulename, FRAME * frame )
 
     /* Check traditional targets $(<) and sources $(>). */
     if ( !rule->actions && !rule->procedure )
-        unknown_rule( frame, NULL, frame->module, rulename );
+        unknown_rule_error( frame, frame->module, rulename );
 
     /* If this rule will be executed for updating the targets then construct the
      * action for make().
@@ -218,15 +213,16 @@ LIST * call_rule( OBJECT * rulename, FRAME * caller_frame, LIST * arg, ... )
 
 
 LIST * call_member_rule(
-	OBJECT * rulename, FRAME * caller_frame, b2::list_ref && self_, b2::lists && args_)
+    OBJECT * rulename, FRAME * caller_frame, b2::list_ref && self_, b2::lists && args_)
 {
     b2::list_ref self(std::move(self_));
     b2::lists args(std::move(args_));
     if (self.empty())
     {
-        backtrace_line(caller_frame);
-        out_printf("warning: object is empty\n");
-        backtrace(caller_frame);
+        b2::list_ref msgs;
+        msgs.push_back( b2::rule_and_args_to_string( caller_frame ) );
+        msgs.push_back( "object is empty." );
+        b2::out_warning( *msgs, caller_frame );
         return L0;
     }
 

--- a/src/engine/function.cpp
+++ b/src/engine/function.cpp
@@ -64,8 +64,6 @@
 #endif
 
 int32_t glob( char const * s, char const * c );
-void backtrace( FRAME * );
-void backtrace_line( FRAME * );
 
 #define INSTR_PUSH_EMPTY                   0
 #define INSTR_PUSH_CONSTANT                1
@@ -395,9 +393,10 @@ struct _stack
             #if B2_FUNCTION_STACK_VALIDATE
             if (stack->get<char>() != saved)
             {
-                backtrace_line( frame );
-                err_printf( "error: stack check failed.\n" );
-                backtrace( frame );
+                b2::list_ref msgs;
+                msgs.push_back( b2::rule_and_args_to_string( frame ) );
+                msgs.push_back( "stack check failed." );
+                b2::out_warning( *msgs, frame );
                 b2::ensure( false );
             }
             #endif
@@ -721,6 +720,9 @@ static void function_default_named_variable( JAM_FUNCTION * function,
     var_set( frame->module, name, value, VAR_DEFAULT );
 }
 
+#define QUOTE_EXPANDED(x) STRINGIFY(x)
+#define STRINGIFY(x) #x
+
 static LIST * function_call_rule( JAM_FUNCTION * function, FRAME * frame,
     STACK * s, int32_t n_args, char const * unexpanded, OBJECT * file, int32_t line )
 {
@@ -735,9 +737,11 @@ static LIST * function_call_rule( JAM_FUNCTION * function, FRAME * frame,
 
     if ( first.empty() )
     {
-        backtrace_line( frame );
-        out_printf( "warning: rulename %s expands to empty string\n", unexpanded );
-        backtrace( frame );
+        b2::list_ref msgs;
+        msgs.push_back( b2::rule_and_args_to_string( frame ) );
+        msgs.push_back( std::string("rulename \"")
+            + unexpanded + "\" expands to empty string." );
+        b2::out_warning( *msgs, frame );
         first.reset();
         for ( i = 0; i < n_args; ++i )
             list_free( s->pop<LIST *>() );
@@ -752,9 +756,10 @@ static LIST * function_call_rule( JAM_FUNCTION * function, FRAME * frame,
 
     if ( n_args > LOL_MAX )
     {
-        out_printf( "ERROR: rules are limited to %d arguments\n", LOL_MAX );
-        backtrace( &inner );
-        b2::clean_exit( EXITBAD );
+        b2::list_ref msgs;
+        msgs.push_back(
+            "rules are limited to " QUOTE_EXPANDED(LOL_MAX) " arguments." );
+        b2::out_error( *msgs, frame );
     }
 
     for ( i = 0; i < n_args; ++i )
@@ -783,9 +788,10 @@ static LIST * function_call_member_rule( JAM_FUNCTION * function, FRAME * frame,
 {
     if ( n_args > LOL_MAX )
     {
-        out_printf( "ERROR: member rules are limited to %d arguments\n", LOL_MAX );
-        backtrace( frame );
-        b2::clean_exit( EXITBAD );
+        b2::list_ref msgs;
+        msgs.push_back(
+            "member rules are limited to " QUOTE_EXPANDED(LOL_MAX) " arguments." );
+        b2::out_error( *msgs, frame );
     }
 
     b2::list_ref first(s->pop<LIST *>(), true);
@@ -799,6 +805,8 @@ static LIST * function_call_member_rule( JAM_FUNCTION * function, FRAME * frame,
     return call_member_rule( rulename, frame, std::move(first), std::move(args) );
 }
 
+#undef QUOTE_EXPANDED
+#undef STRINGIFY
 
 /* Variable expansion */
 

--- a/src/engine/jam.h
+++ b/src/engine/jam.h
@@ -29,36 +29,36 @@
 
 #ifdef VMS
 
-#include <ctype.h>
-#include <file.h>
-#include <signal.h>
-#include <stat.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
-#include <types.h>
-#include <unistd.h>
-#include <unixlib.h>
+#  include <ctype.h>
+#  include <file.h>
+#  include <signal.h>
+#  include <stat.h>
+#  include <stdio.h>
+#  include <stdlib.h>
+#  include <string.h>
+#  include <time.h>
+#  include <types.h>
+#  include <unistd.h>
+#  include <unixlib.h>
 
-#define OSMINOR "OS=VMS"
-#define OSMAJOR "VMS=true"
-#define OS_VMS
-#define MAXLINE 1024 /* longest 'together' actions */
-#define PATH_DELIM '/' /* use CRTL POSIX-style handling */
-#define SPLITPATH ','
-#define EXITOK EXIT_SUCCESS
-#define EXITBAD EXIT_FAILURE
-#define DOWNSHIFT_PATHS
+#  define OSMINOR "OS=VMS"
+#  define OSMAJOR "VMS=true"
+#  define OS_VMS
+#  define MAXLINE 1024 /* longest 'together' actions */
+#  define PATH_DELIM '/' /* use CRTL POSIX-style handling */
+#  define SPLITPATH ','
+#  define EXITOK EXIT_SUCCESS
+#  define EXITBAD EXIT_FAILURE
+#  define DOWNSHIFT_PATHS
 
 /* This may be inaccurate. */
-#ifndef __DECC
-#define OSPLAT "OSPLAT=VAX"
-#endif
+#  ifndef __DECC
+#    define OSPLAT "OSPLAT=VAX"
+#  endif
 
-#define glob jam_glob /* use jam's glob, not CRTL's */
+#  define glob jam_glob /* use jam's glob, not CRTL's */
 
-#endif
+#endif /* #ifdef VMS */
 
 /*
  * Windows NT
@@ -66,42 +66,42 @@
 
 #ifdef NT
 
-#include <ctype.h>
-#include <fcntl.h>
-#include <malloc.h>
-#ifndef __MWERKS__
-#include <memory.h>
-#endif
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
+#  include <ctype.h>
+#  include <fcntl.h>
+#  include <malloc.h>
+#  ifndef __MWERKS__
+#    include <memory.h>
+#  endif
+#  include <signal.h>
+#  include <stdio.h>
+#  include <stdlib.h>
+#  include <string.h>
+#  include <time.h>
 
-#define OSMAJOR "NT=true"
-#define OSMINOR "OS=NT"
-#define OS_NT
-#define SPLITPATH ';'
-#define MAXLINE (undefined__see_execnt_c) /* max chars per command line */
-#define USE_EXECNT
-#define USE_PATHNT
-#define PATH_DELIM '\\'
+#  define OSMAJOR "NT=true"
+#  define OSMINOR "OS=NT"
+#  define OS_NT
+#  define SPLITPATH ';'
+#  define MAXLINE (undefined__see_execnt_c) /* max chars per command line */
+#  define USE_EXECNT
+#  define USE_PATHNT
+#  define PATH_DELIM '\\'
 
 /* AS400 cross-compile from NT. */
 
-#ifdef AS400
-#undef OSMINOR
-#undef OSMAJOR
-#define OSMAJOR "AS400=true"
-#define OSMINOR "OS=AS400"
-#define OS_AS400
-#endif
+#  ifdef AS400
+#    undef OSMINOR
+#    undef OSMAJOR
+#    define OSMAJOR "AS400=true"
+#    define OSMINOR "OS=AS400"
+#    define OS_AS400
+#  endif
 
 /* Metrowerks Standard Library on Windows. */
 
-#ifdef __MSL__
-#undef HAVE_POPEN
-#endif
+#  ifdef __MSL__
+#    undef HAVE_POPEN
+#  endif
 
 #endif /* #ifdef NT */
 
@@ -111,24 +111,24 @@
 
 #ifdef MINGW
 
-#include <ctype.h>
-#include <fcntl.h>
-#include <malloc.h>
-#include <memory.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <time.h>
+#  include <ctype.h>
+#  include <fcntl.h>
+#  include <malloc.h>
+#  include <memory.h>
+#  include <signal.h>
+#  include <stdio.h>
+#  include <stdlib.h>
+#  include <string.h>
+#  include <time.h>
 
-#define OSMAJOR "MINGW=true"
-#define OSMINOR "OS=MINGW"
-#define OS_NT
-#define SPLITPATH ';'
-#define MAXLINE 996 /* max chars per command line */
-#define USE_EXECUNIX
-#define USE_PATHNT
-#define PATH_DELIM '\\'
+#  define OSMAJOR "MINGW=true"
+#  define OSMINOR "OS=MINGW"
+#  define OS_NT
+#  define SPLITPATH ';'
+#  define MAXLINE 996 /* max chars per command line */
+#  define USE_EXECUNIX
+#  define USE_PATHNT
+#  define PATH_DELIM '\\'
 
 #endif /* #ifdef MINGW */
 
@@ -138,232 +138,232 @@
 
 #ifndef OSMINOR
 
-#define OSMAJOR "UNIX=true"
-#define USE_EXECUNIX
-#define USE_FILEUNIX
-#define USE_PATHUNIX
-#define PATH_DELIM '/'
+#  define OSMAJOR "UNIX=true"
+#  define USE_EXECUNIX
+#  define USE_FILEUNIX
+#  define USE_PATHUNIX
+#  define PATH_DELIM '/'
 
-#ifdef _AIX
-#define unix
-#define MAXLINE 23552 /* 24k - 1k, max chars per command line */
-#define OSMINOR "OS=AIX"
-#define OS_AIX
-#define NO_VFORK
-#endif
-#ifdef AMIGA
-#define OSMINOR "OS=AMIGA"
-#define OS_AMIGA
-#endif
-#ifdef __BEOS__
-#define unix
-#define OSMINOR "OS=BEOS"
-#define OS_BEOS
-#define NO_VFORK
-#endif
-#ifdef __bsdi__
-#define OSMINOR "OS=BSDI"
-#define OS_BSDI
-#endif
-#if defined(COHERENT) && defined(_I386)
-#define OSMINOR "OS=COHERENT"
-#define OS_COHERENT
-#define NO_VFORK
-#endif
-#if defined(__cygwin__) || defined(__CYGWIN__)
-#define OSMINOR "OS=CYGWIN"
-#define OS_CYGWIN
-#endif
-#if defined(__FreeBSD__) && !defined(__DragonFly__)
-#define OSMINOR "OS=FREEBSD"
-#define OS_FREEBSD
-#endif
-#ifdef __DragonFly__
-#define OSMINOR "OS=DRAGONFLYBSD"
-#define OS_DRAGONFLYBSD
-#endif
-#ifdef __DGUX__
-#define OSMINOR "OS=DGUX"
-#define OS_DGUX
-#endif
-#ifdef __GNU__
-#define OSMINOR "OS=HURD"
-#define OS_HURD
-#endif
-#ifdef __hpux
-#define OSMINOR "OS=HPUX"
-#define OS_HPUX
-#endif
-#ifdef __HAIKU__
-#define unix
-#define OSMINOR "OS=HAIKU"
-#define OS_HAIKU
-#endif
-#ifdef __OPENNT
-#define unix
-#define OSMINOR "OS=INTERIX"
-#define OS_INTERIX
-#define NO_VFORK
-#endif
-#ifdef __sgi
-#define OSMINOR "OS=IRIX"
-#define OS_IRIX
-#define NO_VFORK
-#endif
-#ifdef __ISC
-#define OSMINOR "OS=ISC"
-#define OS_ISC
-#define NO_VFORK
-#endif
-#if defined(linux) || defined(__linux) || defined(__linux__) \
+#  ifdef _AIX
+#    define unix
+#    define MAXLINE 23552 /* 24k - 1k, max chars per command line */
+#    define OSMINOR "OS=AIX"
+#    define OS_AIX
+#    define NO_VFORK
+#  endif
+#  ifdef AMIGA
+#    define OSMINOR "OS=AMIGA"
+#    define OS_AMIGA
+#  endif
+#  ifdef __BEOS__
+#    define unix
+#    define OSMINOR "OS=BEOS"
+#    define OS_BEOS
+#    define NO_VFORK
+#  endif
+#  ifdef __bsdi__
+#    define OSMINOR "OS=BSDI"
+#    define OS_BSDI
+#  endif
+#  if defined(COHERENT) && defined(_I386)
+#    define OSMINOR "OS=COHERENT"
+#    define OS_COHERENT
+#    define NO_VFORK
+#  endif
+#  if defined(__cygwin__) || defined(__CYGWIN__)
+#    define OSMINOR "OS=CYGWIN"
+#    define OS_CYGWIN
+#  endif
+#  if defined(__FreeBSD__) && !defined(__DragonFly__)
+#    define OSMINOR "OS=FREEBSD"
+#    define OS_FREEBSD
+#  endif
+#  ifdef __DragonFly__
+#    define OSMINOR "OS=DRAGONFLYBSD"
+#    define OS_DRAGONFLYBSD
+#  endif
+#  ifdef __DGUX__
+#    define OSMINOR "OS=DGUX"
+#    define OS_DGUX
+#  endif
+#  ifdef __GNU__
+#    define OSMINOR "OS=HURD"
+#    define OS_HURD
+#  endif
+#  ifdef __hpux
+#    define OSMINOR "OS=HPUX"
+#    define OS_HPUX
+#  endif
+#  ifdef __HAIKU__
+#    define unix
+#    define OSMINOR "OS=HAIKU"
+#    define OS_HAIKU
+#  endif
+#  ifdef __OPENNT
+#    define unix
+#    define OSMINOR "OS=INTERIX"
+#    define OS_INTERIX
+#    define NO_VFORK
+#  endif
+#  ifdef __sgi
+#    define OSMINOR "OS=IRIX"
+#    define OS_IRIX
+#    define NO_VFORK
+#  endif
+#  ifdef __ISC
+#    define OSMINOR "OS=ISC"
+#    define OS_ISC
+#    define NO_VFORK
+#  endif
+#  if defined(linux) || defined(__linux) || defined(__linux__) \
 	|| defined(__gnu_linux__)
-#define OSMINOR "OS=LINUX"
-#define OS_LINUX
-#ifndef unix
-#define unix
-#endif
-#endif
-#ifdef __Lynx__
-#define OSMINOR "OS=LYNX"
-#define OS_LYNX
-#define NO_VFORK
-#define unix
-#endif
-#ifdef __MACHTEN__
-#define OSMINOR "OS=MACHTEN"
-#define OS_MACHTEN
-#endif
-#ifdef mpeix
-#define unix
-#define OSMINOR "OS=MPEIX"
-#define OS_MPEIX
-#define NO_VFORK
-#endif
-#ifdef __MVS__
-#define unix
-#define OSMINOR "OS=MVS"
-#define OS_MVS
-#endif
-#ifdef _ATT4
-#define OSMINOR "OS=NCR"
-#define OS_NCR
-#endif
-#ifdef __NetBSD__
-#define unix
-#define OSMINOR "OS=NETBSD"
-#define OS_NETBSD
-#define NO_VFORK
-#endif
-#ifdef __QNX__
-#define unix
-#ifdef __QNXNTO__
-#define OSMINOR "OS=QNXNTO"
-#define OS_QNXNTO
-#else
-#define OSMINOR "OS=QNX"
-#define OS_QNX
-#define NO_VFORK
-#define MAXLINE 996 /* max chars per command line */
-#endif
-#endif
-#ifdef NeXT
-#ifdef __APPLE__
-#define OSMINOR "OS=RHAPSODY"
-#define OS_RHAPSODY
-#else
-#define OSMINOR "OS=NEXT"
-#define OS_NEXT
-#endif
-#endif
-#ifdef __APPLE__
-#define unix
-#define OSMINOR "OS=MACOSX"
-#define OS_MACOSX
-#endif
-#ifdef __osf__
-#ifndef unix
-#define unix
-#endif
-#define OSMINOR "OS=OSF"
-#define OS_OSF
-#endif
-#ifdef _SEQUENT_
-#define OSMINOR "OS=PTX"
-#define OS_PTX
-#endif
-#ifdef M_XENIX
-#define OSMINOR "OS=SCO"
-#define OS_SCO
-#define NO_VFORK
-#endif
-#ifdef sinix
-#define unix
-#define OSMINOR "OS=SINIX"
-#define OS_SINIX
-#endif
-#if defined(__svr4__) || defined(__SVR4)
-#define OSMINOR "OS=SOLARIS"
-#define OS_SOLARIS
-#elif defined(__sun__) || defined(__sun) || defined(sun)
-#define OSMINOR "OS=SUNOS"
-#define OS_SUNOS
-#endif
-#ifdef ultrix
-#define OSMINOR "OS=ULTRIX"
-#define OS_ULTRIX
-#endif
-#ifdef _UNICOS
-#define OSMINOR "OS=UNICOS"
-#define OS_UNICOS
-#endif
-#if defined(__USLC__) && !defined(M_XENIX)
-#define OSMINOR "OS=UNIXWARE"
-#define OS_UNIXWARE
-#endif
-#ifdef __OpenBSD__
-#define OSMINOR "OS=OPENBSD"
-#define OS_OPENBSD
-#ifndef unix
-#define unix
-#endif
-#endif
-#if defined(__FreeBSD_kernel__) && !defined(__FreeBSD__)
-#define OSMINOR "OS=KFREEBSD"
-#define OS_KFREEBSD
-#endif
-#ifndef OSMINOR
-#define OSMINOR "OS=UNKNOWN"
-#endif
+#    define OSMINOR "OS=LINUX"
+#    define OS_LINUX
+#    ifndef unix
+#      define unix
+#    endif
+#  endif
+#  ifdef __Lynx__
+#    define OSMINOR "OS=LYNX"
+#    define OS_LYNX
+#    define NO_VFORK
+#    define unix
+#  endif
+#  ifdef __MACHTEN__
+#    define OSMINOR "OS=MACHTEN"
+#    define OS_MACHTEN
+#  endif
+#  ifdef mpeix
+#    define unix
+#    define OSMINOR "OS=MPEIX"
+#    define OS_MPEIX
+#    define NO_VFORK
+#  endif
+#  ifdef __MVS__
+#    define unix
+#    define OSMINOR "OS=MVS"
+#    define OS_MVS
+#  endif
+#  ifdef _ATT4
+#    define OSMINOR "OS=NCR"
+#    define OS_NCR
+#  endif
+#  ifdef __NetBSD__
+#    define unix
+#    define OSMINOR "OS=NETBSD"
+#    define OS_NETBSD
+#    define NO_VFORK
+#  endif
+#  ifdef __QNX__
+#    define unix
+#    ifdef __QNXNTO__
+#      define OSMINOR "OS=QNXNTO"
+#      define OS_QNXNTO
+#    else
+#      define OSMINOR "OS=QNX"
+#      define OS_QNX
+#      define NO_VFORK
+#      define MAXLINE 996 /* max chars per command line */
+#    endif
+#  endif
+#  ifdef NeXT
+#    ifdef __APPLE__
+#      define OSMINOR "OS=RHAPSODY"
+#      define OS_RHAPSODY
+#    else
+#      define OSMINOR "OS=NEXT"
+#      define OS_NEXT
+#    endif
+#  endif
+#  ifdef __APPLE__
+#    define unix
+#    define OSMINOR "OS=MACOSX"
+#    define OS_MACOSX
+#  endif
+#  ifdef __osf__
+#    ifndef unix
+#      define unix
+#    endif
+#    define OSMINOR "OS=OSF"
+#    define OS_OSF
+#  endif
+#  ifdef _SEQUENT_
+#    define OSMINOR "OS=PTX"
+#    define OS_PTX
+#  endif
+#  ifdef M_XENIX
+#    define OSMINOR "OS=SCO"
+#    define OS_SCO
+#    define NO_VFORK
+#  endif
+#  ifdef sinix
+#    define unix
+#    define OSMINOR "OS=SINIX"
+#    define OS_SINIX
+#  endif
+#  if defined(__svr4__) || defined(__SVR4)
+#    define OSMINOR "OS=SOLARIS"
+#    define OS_SOLARIS
+#  elif defined(__sun__) || defined(__sun) || defined(sun)
+#    define OSMINOR "OS=SUNOS"
+#    define OS_SUNOS
+#  endif
+#  ifdef ultrix
+#    define OSMINOR "OS=ULTRIX"
+#    define OS_ULTRIX
+#  endif
+#  ifdef _UNICOS
+#    define OSMINOR "OS=UNICOS"
+#    define OS_UNICOS
+#  endif
+#  if defined(__USLC__) && !defined(M_XENIX)
+#    define OSMINOR "OS=UNIXWARE"
+#    define OS_UNIXWARE
+#  endif
+#  ifdef __OpenBSD__
+#    define OSMINOR "OS=OPENBSD"
+#    define OS_OPENBSD
+#    ifndef unix
+#      define unix
+#    endif
+#  endif
+#  if defined(__FreeBSD_kernel__) && !defined(__FreeBSD__)
+#    define OSMINOR "OS=KFREEBSD"
+#    define OS_KFREEBSD
+#  endif
+#  ifndef OSMINOR
+#    define OSMINOR "OS=UNKNOWN"
+#  endif
 
 /* All the UNIX includes */
 
-#include <sys/types.h>
+#  include <sys/types.h>
 
-#ifndef OS_MPEIX
-#include <sys/file.h>
-#endif
+#  ifndef OS_MPEIX
+#    include <sys/file.h>
+#  endif
 
-#include <ctype.h>
-#include <fcntl.h>
-#include <signal.h>
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
-#include <unistd.h>
+#  include <ctype.h>
+#  include <fcntl.h>
+#  include <signal.h>
+#  include <stdio.h>
+#  include <string.h>
+#  include <time.h>
+#  include <unistd.h>
 
-#ifndef OS_QNX
-#include <memory.h>
-#endif
+#  ifndef OS_QNX
+#    include <memory.h>
+#  endif
 
-#ifndef OS_ULTRIX
-#include <stdlib.h>
-#endif
+#  ifndef OS_ULTRIX
+#    include <stdlib.h>
+#  endif
 
-#if !defined(OS_BSDI) && !defined(OS_FREEBSD) && !defined(OS_DRAGONFLYBSD) \
+#  if !defined(OS_BSDI) && !defined(OS_FREEBSD) && !defined(OS_DRAGONFLYBSD) \
 	&& !defined(OS_NEXT) && !defined(OS_MACHTEN) && !defined(OS_MACOSX) \
 	&& !defined(OS_RHAPSODY) && !defined(OS_MVS) && !defined(OS_OPENBSD)
-#include <malloc.h>
-#endif
+#    include <malloc.h>
+#  endif
 
 #endif /* #ifndef OSMINOR */
 
@@ -397,11 +397,11 @@
 #endif
 
 #ifdef __mips__
-#if _MIPS_SIM == _MIPS_SIM_ABI64
-#define OSPLAT "OSPLAT=MIPS64"
-#elif _MIPS_SIM == _MIPS_SIM_ABI32
-#define OSPLAT "OSPLAT=MIPS32"
-#endif
+#  if _MIPS_SIM == _MIPS_SIM_ABI64
+#    define OSPLAT "OSPLAT=MIPS64"
+#  elif _MIPS_SIM == _MIPS_SIM_ABI32
+#    define OSPLAT "OSPLAT=MIPS32"
+#  endif
 #endif
 
 #if defined(__arm__) || defined(_M_ARM)
@@ -421,11 +421,11 @@
 #endif
 
 #if defined(__riscv) || defined(__riscv__)
-#if __riscv_xlen == 64
-#define OSPLAT "OSPLAT=RISCV64"
-#elif __riscv_xlen == 32
-#define OSPLAT "OSPLAT=RISCV32"
-#endif
+#  if __riscv_xlen == 64
+#    define OSPLAT "OSPLAT=RISCV64"
+#  elif __riscv_xlen == 32
+#    define OSPLAT "OSPLAT=RISCV32"
+#  endif
 #endif
 
 #ifndef OSPLAT

--- a/src/engine/outerr.cpp
+++ b/src/engine/outerr.cpp
@@ -53,7 +53,7 @@ void backtrace_line( FRAME * frame )
 void backtrace( FRAME * frame )
 {
     if ( !frame ) return;
-    while ( ( frame = frame->prev ) )
+    while ( frame = frame->prev )
         backtrace_line( frame );
 }
 

--- a/src/engine/outerr.cpp
+++ b/src/engine/outerr.cpp
@@ -53,7 +53,7 @@ void backtrace_line( FRAME * frame )
 void backtrace( FRAME * frame )
 {
     if ( !frame ) return;
-    while ( frame = frame->prev )
+    while ( ( frame = frame->prev ) )
         backtrace_line( frame );
 }
 

--- a/src/engine/outerr.cpp
+++ b/src/engine/outerr.cpp
@@ -70,9 +70,9 @@ void unknown_rule_error( FRAME * frame, module_t * modul, OBJECT * rule_name )
         + "\" unknown in ";
     msgs.push_back( modul->name
         ? msg + "module \"" + modul->name->str() + "\"."
-        : msg + "global module." );
+        : msg + "root module." );
 
-    b2::out_error(*msgs, frame);
+    b2::out_error( *msgs, frame );
 }
 
 

--- a/src/engine/outerr.cpp
+++ b/src/engine/outerr.cpp
@@ -13,27 +13,92 @@ Distributed under the Boost Software License, Version 1.0.
 #include "startup.h"
 
 
-std::string b2::args_to_string(LOL * lol)
+/* from builtins.cpp */
+void get_source_line( FRAME * frame, char const * * file, int * line );
+
+void print_source_line( FRAME * frame )
+{
+    char const * file;
+    int line;
+    get_source_line( frame, &file, &line );
+    if ( line > 0 )
+        out_printf( "%s:%d:", file, line );
+    else if ( line == 0 )
+        out_printf( "%s:", file );
+    else
+        out_printf( "(builtin):" );
+}
+
+/*
+ * backtrace_line() - print a single line of error backtrace for the given
+ * frame.
+ */
+void backtrace_line( FRAME * frame )
+{
+    if ( frame == 0 )
+    {
+        out_printf( "(no frame):" );
+    }
+    else
+    {
+        print_source_line( frame );
+        out_printf( " in %s\n", frame->rulename );
+    }
+}
+
+/*
+ * backtrace() - Print the entire backtrace from the given frame to the Jambase
+ * which invoked it.
+ */
+void backtrace( FRAME * frame )
+{
+    if ( !frame ) return;
+    while ( ( frame = frame->prev ) )
+        backtrace_line( frame );
+}
+
+/*
+ * unknown_rule_error() - reports an unknown rule occurrence to the user and exits
+ */
+void unknown_rule_error( FRAME * frame, module_t * modul, OBJECT * rule_name )
+{
+    b2::list_ref msgs;
+
+    msgs.push_back( b2::rule_and_args_to_string( frame ) );
+
+    std::string msg = std::string("rule \"") + rule_name->str()
+        + "\" unknown in ";
+    msgs.push_back( modul->name
+        ? msg + "module \"" + modul->name->str() + "\"."
+        : msg + "global module." );
+
+    b2::out_error(*msgs, frame);
+}
+
+
+namespace b2 {
+
+std::string args_to_string(LOL * lol)
 {
     std::string res;
     for (int32_t i = 0; i < lol->count; ++i)
     {
         if (i) res += " :";
-        for ( auto el : b2::list_cref(lol->list[i]) )
+        for ( auto el : list_cref(lol->list[i]) )
             res += std::string(" ") + el->str();
     }
     return res;
 }
 
-// TODO: move these from builtins
-//void print_source_line( FRAME * );
-void backtrace_line   ( FRAME * );
-void backtrace        ( FRAME * );
+std::string rule_and_args_to_string(FRAME * frame)
+{
+    return std::string(frame->rulename) + args_to_string( frame->args );
+}
 
 /*
  * Error function that try to mimic the b2::jam::errors::backtrace.
  */
-void b2::out_emit(const char * prefix,
+void out_emit(const char * prefix,
     LIST * messages, FRAME * frame,
     bool with_backtrace, bool exit)
 {
@@ -52,10 +117,17 @@ void b2::out_emit(const char * prefix,
 
     if (with_backtrace && has_prev) backtrace( frame->prev );
 
-    if (exit) b2::clean_exit( EXITBAD );
+    if (exit) clean_exit( EXITBAD );
 }
 
-void b2::out_error(LIST * messages, FRAME * frame)
+void out_error(LIST * messages, FRAME * frame)
 {
     out_emit("error:", messages, frame, true, true);
 }
+
+void out_warning(LIST * messages, FRAME * frame)
+{
+    out_emit("warning:", messages, frame, false, false);
+}
+
+} // namespace b2

--- a/src/engine/outerr.h
+++ b/src/engine/outerr.h
@@ -12,18 +12,29 @@ Distributed under the Boost Software License, Version 1.0.
 
 #include <string>
 
+/*
+ * Legacy error related functions.
+ */
+void print_source_line  ( FRAME * );
+//void backtrace_line     ( FRAME * );
+//void backtrace          ( FRAME * );
+void unknown_rule_error ( FRAME * , module_t * , OBJECT * );
+
 namespace b2 {
 
 /*
- * Error related functions and helpers.
+ * Error functions and helpers.
  */
 
 std::string args_to_string(LOL * lol);
+
+std::string rule_and_args_to_string(FRAME * frame);
 
 void out_emit(const char * prefix, LIST * messages,
     FRAME * frame, bool with_backtrace, bool exit);
 
 void out_error(LIST * messages, FRAME * frame);
+void out_warning(LIST * messages, FRAME * frame);
 
 } // namespace b2
 


### PR DESCRIPTION
+ better indenting of preprocessor directives in `jam.h`
+ `print_source_line`, `backtrace_line`, `backtrace`, and `unknown_rule_error` (formerly `unknown_rule`) function definitions moved from `builtins.cpp` to `outerr.cpp`
+ new `rule_and_args_to_string` and `out_warning` functions added
+ `COMMAND` builtin rule is now an alias for `SHELL`, to reflect the documentation and also because it is not used and one day might be discontinued
+ new function `try_bind_module` added to `builtins.cpp`, to check for modules before the binding and error/warning diagnostics; currently used by both `IMPORT` and `EXPORT` builtin rules <sup>[1]</sup>
+ new template function `b2::find_hash` added to simplify usage of `hash_find`, this is in `builtins.cpp` by now
+ use of "_global module_" instead of "_root module_" in messages
+ `builtin_import` (IMPORT) and `builtin_native_rule` (NATIVE_RULE) updated to use outerr functions to emit errors
+ `call_member_rule` in `compile.cpp` updated to emit a warning using `out_warning`
+ `struct _stack::check::operator()` and `function_call_rule` in `function.cpp` now emit a warning using `out_warning`
+ `function_call_rule` e `function_call_member_rule` in `function.cpp` now emit an error using `out_error`

**[1]**
Requesting an import from a non-existent module produces a warning and the use of the global module by `IMPORT`; conversely requesting an export from a non-existent module produces an error by the `EXPORT`. See #565 for details about the rationale.