### PR TITLE
goodbye ping loopback if

### DIFF
--- a/test/core_option_l.py
+++ b/test/core_option_l.py
@@ -2,43 +2,29 @@
 
 # Copyright 2007 Rene Rivera.
 # Copyright 2011 Steven Watanabe
+# Copyright 2026 Paolo Pastori
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.txt or copy at
 # https://www.bfgroup.xyz/b2/LICENSE.txt)
 
 import BoostBuild
+import sys
 
-t = BoostBuild.Tester(pass_toolset=0)
+sleep_s = 1.5
 
-t.write("sleep.bat", """\
-::@timeout /T %1 /NOBREAK >nul
-@ping 127.0.0.1 -n 2 -w 1000 >nul
-@ping 127.0.0.1 -n %1 -w 1000 >nul
-@exit /B 0
-""")
+t = BoostBuild.Tester(pass_toolset=False)
 
 t.write("file.jam", """\
-if $(NT)
-{
-    SLEEP = @call sleep.bat ;
-}
-else
-{
-    SLEEP = sleep ;
-}
-
-actions .a. {
-echo 001
-$(SLEEP) 4
-echo 002
-}
+actions .a. {{
+"{}" -c "import time; time.sleep({})"
+}}
 
 .a. sleeper ;
 
 DEPENDS all : sleeper ;
-""")
+""".format(sys.executable, sleep_s))
 
-t.run_build_system(["-ffile.jam", "-d1", "-l2"], status=1)
-t.expect_output_lines("2 second time limit exceeded")
+t.run_build_system(["-ffile.jam", "-l1"], status=1)
+t.expect_output_lines("1 second time limit exceeded")
 
 t.cleanup()

--- a/test/core_parallel_actions.py
+++ b/test/core_parallel_actions.py
@@ -2,64 +2,49 @@
 
 # Copyright 2006 Rene Rivera.
 # Copyright 2011 Steven Watanabe
+# Copyright 2026 Paolo Pastori
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.txt or https://www.bfgroup.xyz/b2/LICENSE.txt)
 
 import BoostBuild
+import sys
 
-t = BoostBuild.Tester(["-d1"], pass_toolset=0)
-
-t.write("sleep.bat", """\
-::@timeout /T %1 /NOBREAK >nul
-@ping 127.0.0.1 -n 2 -w 1000 >nul
-@ping 127.0.0.1 -n %1 -w 1000 >nul
-@exit /B 0
-""")
+t = BoostBuild.Tester(["-d1"], pass_toolset=False)
 
 t.write("file.jam", """\
-if $(NT)
-{
-    actions sleeper
-    {
-        call sleep.bat $(<:B)
-    }
-}
-else
-{
-    actions sleeper
-    {
-        sleep $(<:B)
-    }
-}
+actions sleeper
+{{
+    "{}" -c "import time; time.sleep($(<:B))"
+}}
 
 rule sleeper
-{
+{{
     DEPENDS $(<) : $(>) ;
-}
+}}
 
 NOTFILE front ;
-sleeper 1.a : front ;
-sleeper 2.a : front ;
-sleeper 3.a : front ;
+sleeper 0.2.a : front ;
+sleeper 0.3.a : front ;
+sleeper 0.4.a : front ;
 NOTFILE choke ;
-DEPENDS choke : 1.a 2.a 3.a ;
-sleeper 1.b : choke ;
-sleeper 2.b : choke ;
-sleeper 3.b : choke ;
-DEPENDS bottom : 1.b 2.b 3.b ;
+DEPENDS choke : 0.2.a 0.3.a 0.4.a ;
+sleeper 0.2.b : choke ;
+sleeper 0.3.b : choke ;
+sleeper 0.4.b : choke ;
+DEPENDS bottom : 0.2.b 0.3.b 0.4.b ;
 DEPENDS all : bottom ;
-""")
+""".format(sys.executable))
 
 t.run_build_system(["-ffile.jam", "-j3"])
 t.expect_output_lines("""\
 ...found 10 targets...
 ...updating 6 targets...
-sleeper [123].a
-sleeper [123].a
-sleeper [123].a
-sleeper [123].b
-sleeper [123].b
-sleeper [123].b
+sleeper 0.[234].a
+sleeper 0.[2-4].a
+sleeper 0.[234].a
+sleeper 0.[2-4].b
+sleeper 0.[234].b
+sleeper 0.[2-4].b
 
 ...updated 6 targets...
 """)

--- a/test/core_parallel_multifile_actions_1.py
+++ b/test/core_parallel_multifile_actions_1.py
@@ -2,6 +2,7 @@
 
 # Copyright 2007 Rene Rivera.
 # Copyright 2011 Steven Watanabe
+# Copyright 2026 Paolo Pastori
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.txt or https://www.bfgroup.xyz/b2/LICENSE.txt)
 
@@ -16,51 +17,39 @@
 # depending on target A to be built prematurely.
 
 import BoostBuild
+import sys
 
-t = BoostBuild.Tester(["-d1"], pass_toolset=0)
+sleep1_s = 1.0
+sleep2_s = 0.1
 
-t.write("sleep.bat", """\
-::@timeout /T %1 /NOBREAK >nul
-@ping 127.0.0.1 -n 2 -w 1000 >nul
-@ping 127.0.0.1 -n %1 -w 1000 >nul
-@exit /B 0
-""")
+t = BoostBuild.Tester(["-d1"], pass_toolset=False)
 
 t.write("file.jam", """\
-if $(NT)
-{
-    SLEEP = @call sleep.bat ;
-}
-else
-{
-    SLEEP = sleep ;
-}
-
 actions .gen.
-{
+{{
     echo 001
-    $(SLEEP) 4
+    "{0}" -c "import time; time.sleep({1})"
     echo 002
-}
-rule .use.1 { DEPENDS $(<) : $(>) ; }
+}}
+rule .use.1 {{ DEPENDS $(<) : $(>) ; }}
 actions .use.1
-{
+{{
     echo 003
-}
+}}
 
-rule .use.2 { DEPENDS $(<) : $(>) ; }
+rule .use.2 {{ DEPENDS $(<) : $(>) ; }}
 actions .use.2
-{
-    $(SLEEP) 1
+{{
+    "{0}" -c "import time; time.sleep({2})"
     echo 004
-}
+}}
 
 .gen. g1.generated g2.generated ;
 .use.1 u1.user : g1.generated ;
 .use.2 u2.user : g2.generated ;
 
 DEPENDS all : u1.user u2.user ;
-""")
+""".format(sys.executable, sleep1_s, sleep2_s))
 
 t.run_build_system(["-ffile.jam", "-j2"], stdout="""\
 ...found 5 targets...

--- a/test/core_parallel_multifile_actions_2.py
+++ b/test/core_parallel_multifile_actions_2.py
@@ -2,6 +2,7 @@
 
 # Copyright 2008 Jurko Gospodnetic, Vladimir Prus
 # Copyright 2011 Steven Watanabe
+# Copyright 2026 Paolo Pastori
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.txt or https://www.bfgroup.xyz/b2/LICENSE.txt)
 
@@ -19,44 +20,31 @@
 # prematurely.
 
 import BoostBuild
+import sys
 
-t = BoostBuild.Tester(pass_toolset=0)
+sleep_s = 0.2
 
-t.write("sleep.bat", """\
-::@timeout /T %1 /NOBREAK >nul
-@ping 127.0.0.1 -n 2 -w 1000 >nul
-@ping 127.0.0.1 -n %1 -w 1000 >nul
-@exit /B 0
-""")
+t = BoostBuild.Tester(pass_toolset=False)
 
 t.write("file.jam", """\
-if $(NT)
-{
-    SLEEP = @call sleep.bat ;
-}
-else
-{
-    SLEEP = sleep ;
-}
-
 actions link
-{
-    $(SLEEP) 1
+{{
+    "{}" -c "import time; time.sleep({})"
     echo 001 - linked
-}
+}}
 
 link dll lib ;
 
 actions install
-{
+{{
     echo 002 - installed
-}
+}}
 
 install installed_dll : dll ;
 DEPENDS installed_dll : dll ;
 
 DEPENDS all : lib installed_dll ;
-""")
+""".format(sys.executable, sleep_s))
 
 t.run_build_system(["-ffile.jam", "-j2"], stdout="""\
 ...found 4 targets...

--- a/test/scanner_causing_rebuilds.py
+++ b/test/scanner_causing_rebuilds.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # Copyright 2012 Jurko Gospodnetic
+# Copyright 2026 Paolo Pastori
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.txt or https://www.bfgroup.xyz/b2/LICENSE.txt)
 
@@ -17,13 +18,15 @@
 # targets depending on it to be updated/rebuilt as well.
 
 import BoostBuild
+import sys
 
-t = BoostBuild.Tester(use_test_config=False)
+sleep_s = 0.5
 
-t.write("foo.jam", r"""
+t = BoostBuild.Tester()
+
+t.write("foo.jam", """\
 import common ;
 import generators ;
-import modules ;
 import type ;
 import types/cpp ;
 
@@ -31,23 +34,10 @@ type.register FOO : foo ;
 type.register BAR : bar ;
 generators.register-standard foo.foo : FOO : CPP BAR ;
 
-local rule sleep-cmd ( delay )
-{
-    if [ modules.peek : NT ]
-    {
-        return ping 127.0.0.1 -n $(delay) -w 1000 >NUL ;
-    }
-    else
-    {
-        return sleep $(delay) ;
-    }
-}
-
-.touch = [ common.file-creation-command ] ;
-.sleep = [ sleep-cmd 2 ] ;
+.touch = [ common.file-touch-command ] ;
 
 rule foo ( cpp bar : foo : properties * )
-{
+{{
     # We add the INCLUDE relationship between our generated CPP & BAR targets
     # explicitly instead of relying on Boost Jam's internal implementation
     # detail - automatically adding such relationships between all files
@@ -56,24 +46,20 @@ rule foo ( cpp bar : foo : properties * )
     # Note that adding this relationship by adding an #include directive in our
     # generated CPP file is not good enough as such a relationship would get
     # added only after the scanner target's relationships have already been
-    # established and they (as affected by our initial INCLUDE relationship) are
-    # the original reason for this test failing.
+    # established and they (as affected by our initial INCLUDE relationship)
+    # are the original reason for this test failing.
     INCLUDES $(cpp) : $(bar) ;
-}
+}}
 
 actions foo
-{
+{{
     $(.touch) "$(<[1])"
-    $(.sleep)
+    "{}" -c "import time; time.sleep({})"
     $(.touch) "$(<[2])"
-}
-""")
+}}
+""".format(sys.executable, sleep_s))
 
-t.write(
-    'foo.py',
-"""
-import os
-
+t.write("foo.py", """\
 from b2.build import type as type_, generators
 from b2.tools import common
 from b2.manager import get_manager
@@ -84,11 +70,6 @@ ENGINE = MANAGER.engine()
 type_.register('FOO', ['foo'])
 type_.register('BAR', ['bar'])
 generators.register_standard('foo.foo', ['FOO'], ['CPP', 'BAR'])
-
-def sleep_cmd(delay):
-    if os.name == 'nt':
-        return 'ping 127.0.0.1 -n {} -w 1000 >NUL'.format(delay)
-    return 'sleep {}'.format(delay)
 
 def foo(targets, sources, properties):
     cpp, bar = targets
@@ -101,20 +82,19 @@ def foo(targets, sources, properties):
     # Note that adding this relationship by adding an #include directive in our
     # generated CPP file is not good enough as such a relationship would get
     # added only after the scanner target's relationships have already been
-    # established and they (as affected by our initial INCLUDE relationship) are
-    # the original reason for this test failing.
+    # established and they (as affected by our initial INCLUDE relationship)
+    # are the original reason for this test failing.
     bjam.call('INCLUDES', cpp, bar)
 
 ENGINE.register_action(
     'foo.foo',
     '''
-    {touch} "$(<[1])"
-    {sleep}
-    {touch} "$(<[2])"
-    '''.format(touch=common.file_creation_command(), sleep=sleep_cmd(2))
+    {{touch}} "$(<[1])"
+    "{}" -c "import time; time.sleep({})"
+    {{touch}} "$(<[2])"
+    '''.format(touch=common.file-touch-command())
 )
-"""
-)
+""".format(sys.executable, sleep_s))
 
 t.write("x.foo", "")
 t.write("jamroot.jam", """\


### PR DESCRIPTION
Let's look at this beautiful piece of code one last time
```
t.write("sleep.bat", """\
::@timeout /T %1 /NOBREAK >nul
@ping 127.0.0.1 -n 2 -w 1000 >nul
@ping 127.0.0.1 -n %1 -w 1000 >nul
@exit /B 0
""")
```
because I removed it from every test it was still in !
It used to be really complicated to get a sleep on Windows, and this has been the solution until now.

The problem is not only depending on network latency, which can change for reasons other than technological ones, but above all running such different tests between the various platforms.

The solution is to use Python everywhere.