### PR TITLE
more on debugger-mi.py (and TestCmd.py)

### DIFF
--- a/test/TestCmd.py
+++ b/test/TestCmd.py
@@ -217,7 +217,7 @@ def match_re(lines=None, res=None):
     if not type(res) is list:
         res = res.split("\n")
     for i in range(min(len(lines), len(res))):
-        if not re.compile("^" + res[i] + "$").search(lines[i]):
+        if not re.match(res[i] + "$", lines[i]):
             return MatchError("Mismatch at line %d\n- %s\n+ %s\n" %
                 (i+1, res[i], lines[i]))
     if len(lines) < len(res):

--- a/test/debugger-mi.py
+++ b/test/debugger-mi.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # Copyright 2016 Steven Watanabe
+# Copyright 2026 Paolo Pastori
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.txt or https://www.bfgroup.xyz/b2/LICENSE.txt)
 
@@ -14,26 +15,26 @@ def split_stdin_stdout(text):
     """stdin is all text after the prompt up to and including
     the next newline.  Everything else is stdout.  stdout
     may contain regular expressions enclosed in {{}}."""
-    prompt = re.escape('(gdb) \n')
-    pattern = re.compile('(?<=%s)((?:\\d*-.*)\n)' % prompt)
+    pattern = re.compile(r'(?<=\(gdb\) \n)((?:\d*-.*)\n)')
     stdin = ''.join(re.findall(pattern, text))
     stdout = re.sub(pattern, '', text)
-    outside_pattern = re.compile(r'(?:\A|(?<=\}\}))(?:[^\{]|(?:\{(?!\{)))*(?:(?=\{\{)|\Z)')
+    outside_pattern = re.compile(r'(?:\A|(?<=\}\}))(?:[^{]|(?:\{(?!\{)))*(?:(?=\{\{)|\Z)')
 
     def escape_line(line):
-        line = re.sub(outside_pattern, lambda m: re.escape(m.group(0)), line)
+        if line == '(gdb) ': return r'\(gdb\) '
+        line = re.sub(outside_pattern, lambda m: m.group(0), line)
         return re.sub(r'\{\{|\}\}', '', line)
 
     stdout = '\n'.join([escape_line(line) for line in stdout.split('\n')])
-    return (stdin,stdout)
+    return (stdin, stdout)
 
 def run(tester, io):
-    (input,output) = split_stdin_stdout(io)
+    (input, output) = split_stdin_stdout(io)
     tester.run_build_system(stdin=input, stdout=output, match=TestCmd.match_re)
 
 def make_tester():
-    return BoostBuild.Tester(["-dmi"], pass_toolset=False, pass_d0=False,
-        use_test_config=False, ignore_toolset_requirements=False, match=TestCmd.match_re)
+    return BoostBuild.Tester(["-dmi"], pass_toolset=False)
+
 
 def test_exec_run():
     t = make_tester()
@@ -46,14 +47,13 @@ def test_exec_run():
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-72^running
+72\^running
 (gdb) 
-*stopped,reason="exited-normally"
+\*stopped,reason="exited-normally"
 (gdb) 
 73-gdb-exit
-73^exit
+73\^exit
 """)
-
     t.cleanup()
 
 def test_exit_status():
@@ -66,13 +66,13 @@ def test_exit_status():
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-72^running
+72\^running
 (gdb) 
 
-*stopped,reason="exited",exit-code="1"
+\*stopped,reason="exited",exit-code="1"
 (gdb) 
 73-gdb-exit
-73^exit
+73\^exit
 """)
     t.cleanup()
 
@@ -95,31 +95,31 @@ def test_exec_step():
 =thread-group-added,id="i1"
 (gdb) 
 -break-insert f
-^done,bkpt={number="1",type="breakpoint",disp="keep",enabled="y",func="f"}
+\^done,bkpt={number="1",type="breakpoint",disp="keep",enabled="y",func="f"}
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-72^running
+72\^running
 (gdb) 
-*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame={func="f",args=[],file="test.jam",fullname="{{.*}}test.jam",line="8"},thread-id="1",stopped-threads="all"
+\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="8"\},thread-id="1",stopped-threads="all"
 (gdb) 
 1-exec-step
-1^running
+1\^running
 (gdb) 
-*stopped,reason="end-stepping-range",frame={func="g",args=[],file="test.jam",fullname="{{.*}}test.jam",line="3"},thread-id="1"
+\*stopped,reason="end-stepping-range",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="3"\},thread-id="1"
 (gdb) 
 2-exec-step
-2^running
+2\^running
 (gdb) 
-*stopped,reason="end-stepping-range",frame={func="g",args=[],file="test.jam",fullname="{{.*}}test.jam",line="4"},thread-id="1"
+\*stopped,reason="end-stepping-range",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="4"\},thread-id="1"
 (gdb) 
 3-exec-step
-3^running
+3\^running
 (gdb) 
-*stopped,reason="end-stepping-range",frame={func="f",args=[],file="test.jam",fullname="{{.*}}test.jam",line="9"},thread-id="1"
+\*stopped,reason="end-stepping-range",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="9"\},thread-id="1"
 (gdb) 
 73-gdb-exit
-73^exit
+73\^exit
 """)
     t.cleanup()
 
@@ -148,36 +148,36 @@ def test_exec_next():
 =thread-group-added,id="i1"
 (gdb) 
 -break-insert f
-^done,bkpt={number="1",type="breakpoint",disp="keep",enabled="y",func="f"}
+\^done,bkpt=\{number="1",type="breakpoint",disp="keep",enabled="y",func="f"\}
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-72^running
+72\^running
 (gdb) 
-*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame={func="f",args=[],file="test.jam",fullname="{{.*}}test.jam",line="7"},thread-id="1",stopped-threads="all"
+\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="7"\},thread-id="1",stopped-threads="all"
 (gdb) 
 1-exec-next
-1^running
+1\^running
 (gdb) 
-*stopped,reason="end-stepping-range",frame={func="f",args=[],file="test.jam",fullname="{{.*}}test.jam",line="8"},thread-id="1"
+\*stopped,reason="end-stepping-range",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="8"\},thread-id="1"
 (gdb) 
 2-exec-next
-2^running
+2\^running
 (gdb) 
-*stopped,reason="end-stepping-range",frame={func="f",args=[],file="test.jam",fullname="{{.*}}test.jam",line="9"},thread-id="1"
+\*stopped,reason="end-stepping-range",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="9"\},thread-id="1"
 (gdb) 
 3-exec-next
-3^running
+3\^running
 (gdb) 
-*stopped,reason="end-stepping-range",frame={func="h",args=[],file="test.jam",fullname="{{.*}}test.jam",line="14"},thread-id="1"
+\*stopped,reason="end-stepping-range",frame=\{func="h",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="14"\},thread-id="1"
 (gdb) 
 4-exec-next
-4^running
+4\^running
 (gdb) 
-*stopped,reason="end-stepping-range",frame={func="module scope",args=[],file="test.jam",fullname="{{.*}}test.jam",line="17"},thread-id="1"
+\*stopped,reason="end-stepping-range",frame=\{func="module scope",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="17"\},thread-id="1"
 (gdb) 
 73-gdb-exit
-73^exit
+73\^exit
 """)
     t.cleanup()
 
@@ -210,34 +210,33 @@ def test_exec_finish():
 =thread-group-added,id="i1"
 (gdb) 
 -break-insert f
-^done,bkpt={number="1",type="breakpoint",disp="keep",enabled="y",func="f"}
+\^done,bkpt=\{number="1",type="breakpoint",disp="keep",enabled="y",func="f"\}
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-72^running
+72\^running
 (gdb) 
-*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame={func="f",args=[],file="test.jam",fullname="{{.*}}test.jam",line="3"},thread-id="1",stopped-threads="all"
+\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="3"\},thread-id="1",stopped-threads="all"
 (gdb) 
 1-exec-finish
-1^running
+1\^running
 (gdb) 
-*stopped,reason="end-stepping-range",frame={func="g",args=[],file="test.jam",fullname="{{.*}}test.jam",line="8"},thread-id="1"
+\*stopped,reason="end-stepping-range",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="8"\},thread-id="1"
 (gdb) 
 2-exec-finish
-2^running
+2\^running
 (gdb) 
-*stopped,reason="end-stepping-range",frame={func="h",args=[],file="test.jam",fullname="{{.*}}test.jam",line="14"},thread-id="1"
+\*stopped,reason="end-stepping-range",frame=\{func="h",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="14"\},thread-id="1"
 (gdb) 
 3-exec-finish
-3^running
+3\^running
 (gdb) 
-*stopped,reason="end-stepping-range",frame={func="module scope",args=[],file="test.jam",fullname="{{.*}}test.jam",line="21"},thread-id="1"
+\*stopped,reason="end-stepping-range",frame=\{func="module scope",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="21"\},thread-id="1"
 (gdb) 
 73-gdb-exit
-73^exit
+73\^exit
 """)
     t.cleanup()
-
 
 def test_breakpoints():
     """Tests the interaction between the following commands:
@@ -266,57 +265,58 @@ def test_breakpoints():
 =thread-group-added,id="i1"
 (gdb) 
 -break-insert f
-^done,bkpt={number="1",type="breakpoint",disp="keep",enabled="y",func="f"}
+\^done,bkpt=\{number="1",type="breakpoint",disp="keep",enabled="y",func="f"\}
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-72^running
+72\^running
 (gdb) 
-*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame={func="f",args=[],file="test.jam",fullname="{{.*}}test.jam",line="3"},thread-id="1",stopped-threads="all"
+\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="3"\},thread-id="1",stopped-threads="all"
 (gdb) 
 -interpreter-exec console kill
-^done
+\^done
 (gdb) 
 -break-insert g
-^done,bkpt={number="2",type="breakpoint",disp="keep",enabled="y",func="g"}
+\^done,bkpt=\{number="2",type="breakpoint",disp="keep",enabled="y",func="g"\}
 (gdb) 
 -break-disable 1
-^done
+\^done
 (gdb) 
 73-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-73^running
+73\^running
 (gdb) 
-*stopped,reason="breakpoint-hit",bkptno="2",disp="keep",frame={func="g",args=[],file="test.jam",fullname="{{.*}}test.jam",line="7"},thread-id="1",stopped-threads="all"
+\*stopped,reason="breakpoint-hit",bkptno="2",disp="keep",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="7"\},thread-id="1",stopped-threads="all"
 (gdb) 
 -interpreter-exec console kill
-^done
+\^done
 (gdb) 
 -break-enable 1
-^done
+\^done
 (gdb) 
 74-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-74^running
+74\^running
 (gdb) 
-*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame={func="f",args=[],file="test.jam",fullname="{{.*}}test.jam",line="3"},thread-id="1",stopped-threads="all"
+\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="3"\},thread-id="1",stopped-threads="all"
 (gdb) 
 -interpreter-exec console kill
-^done
+\^done
 (gdb) 
 -break-delete 1
-^done
+\^done
 (gdb) 
 75-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-75^running
+75\^running
 (gdb) 
-*stopped,reason="breakpoint-hit",bkptno="2",disp="keep",frame={func="g",args=[],file="test.jam",fullname="{{.*}}test.jam",line="7"},thread-id="1",stopped-threads="all"
+\*stopped,reason="breakpoint-hit",bkptno="2",disp="keep",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="7"\},thread-id="1",stopped-threads="all"
 (gdb) 
 76-gdb-exit
-76^exit
+76\^exit
 """)
     t.cleanup()
+
 
 test_exec_run()
 test_exit_status()

--- a/test/debugger-mi.py
+++ b/test/debugger-mi.py
@@ -47,12 +47,12 @@ def test_exec_run():
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-72\^running
+72\\^running
 (gdb) 
 \*stopped,reason="exited-normally"
 (gdb) 
 73-gdb-exit
-73\^exit
+73\\^exit
 """)
     t.cleanup()
 
@@ -66,13 +66,13 @@ def test_exit_status():
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-72\^running
+72\\^running
 (gdb) 
 
 \*stopped,reason="exited",exit-code="1"
 (gdb) 
 73-gdb-exit
-73\^exit
+73\\^exit
 """)
     t.cleanup()
 
@@ -95,31 +95,31 @@ def test_exec_step():
 =thread-group-added,id="i1"
 (gdb) 
 -break-insert f
-\^done,bkpt={number="1",type="breakpoint",disp="keep",enabled="y",func="f"}
+\\^done,bkpt={number="1",type="breakpoint",disp="keep",enabled="y",func="f"}
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-72\^running
+72\\^running
 (gdb) 
 \*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="8"\},thread-id="1",stopped-threads="all"
 (gdb) 
 1-exec-step
-1\^running
+1\\^running
 (gdb) 
 \*stopped,reason="end-stepping-range",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="3"\},thread-id="1"
 (gdb) 
 2-exec-step
-2\^running
+2\\^running
 (gdb) 
 \*stopped,reason="end-stepping-range",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="4"\},thread-id="1"
 (gdb) 
 3-exec-step
-3\^running
+3\\^running
 (gdb) 
 \*stopped,reason="end-stepping-range",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="9"\},thread-id="1"
 (gdb) 
 73-gdb-exit
-73\^exit
+73\\^exit
 """)
     t.cleanup()
 
@@ -148,36 +148,36 @@ def test_exec_next():
 =thread-group-added,id="i1"
 (gdb) 
 -break-insert f
-\^done,bkpt=\{number="1",type="breakpoint",disp="keep",enabled="y",func="f"\}
+\\^done,bkpt=\{number="1",type="breakpoint",disp="keep",enabled="y",func="f"\}
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-72\^running
+72\\^running
 (gdb) 
 \*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="7"\},thread-id="1",stopped-threads="all"
 (gdb) 
 1-exec-next
-1\^running
+1\\^running
 (gdb) 
 \*stopped,reason="end-stepping-range",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="8"\},thread-id="1"
 (gdb) 
 2-exec-next
-2\^running
+2\\^running
 (gdb) 
 \*stopped,reason="end-stepping-range",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="9"\},thread-id="1"
 (gdb) 
 3-exec-next
-3\^running
+3\\^running
 (gdb) 
 \*stopped,reason="end-stepping-range",frame=\{func="h",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="14"\},thread-id="1"
 (gdb) 
 4-exec-next
-4\^running
+4\\^running
 (gdb) 
 \*stopped,reason="end-stepping-range",frame=\{func="module scope",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="17"\},thread-id="1"
 (gdb) 
 73-gdb-exit
-73\^exit
+73\\^exit
 """)
     t.cleanup()
 
@@ -210,31 +210,31 @@ def test_exec_finish():
 =thread-group-added,id="i1"
 (gdb) 
 -break-insert f
-\^done,bkpt=\{number="1",type="breakpoint",disp="keep",enabled="y",func="f"\}
+\\^done,bkpt=\{number="1",type="breakpoint",disp="keep",enabled="y",func="f"\}
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-72\^running
+72\\^running
 (gdb) 
 \*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="3"\},thread-id="1",stopped-threads="all"
 (gdb) 
 1-exec-finish
-1\^running
+1\\^running
 (gdb) 
 \*stopped,reason="end-stepping-range",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="8"\},thread-id="1"
 (gdb) 
 2-exec-finish
-2\^running
+2\\^running
 (gdb) 
 \*stopped,reason="end-stepping-range",frame=\{func="h",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="14"\},thread-id="1"
 (gdb) 
 3-exec-finish
-3\^running
+3\\^running
 (gdb) 
 \*stopped,reason="end-stepping-range",frame=\{func="module scope",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="21"\},thread-id="1"
 (gdb) 
 73-gdb-exit
-73\^exit
+73\\^exit
 """)
     t.cleanup()
 
@@ -265,55 +265,55 @@ def test_breakpoints():
 =thread-group-added,id="i1"
 (gdb) 
 -break-insert f
-\^done,bkpt=\{number="1",type="breakpoint",disp="keep",enabled="y",func="f"\}
+\\^done,bkpt=\{number="1",type="breakpoint",disp="keep",enabled="y",func="f"\}
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-72\^running
+72\\^running
 (gdb) 
 \*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="3"\},thread-id="1",stopped-threads="all"
 (gdb) 
 -interpreter-exec console kill
-\^done
+\\^done
 (gdb) 
 -break-insert g
-\^done,bkpt=\{number="2",type="breakpoint",disp="keep",enabled="y",func="g"\}
+\\^done,bkpt=\{number="2",type="breakpoint",disp="keep",enabled="y",func="g"\}
 (gdb) 
 -break-disable 1
-\^done
+\\^done
 (gdb) 
 73-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-73\^running
+73\\^running
 (gdb) 
 \*stopped,reason="breakpoint-hit",bkptno="2",disp="keep",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="7"\},thread-id="1",stopped-threads="all"
 (gdb) 
 -interpreter-exec console kill
-\^done
+\\^done
 (gdb) 
 -break-enable 1
-\^done
+\\^done
 (gdb) 
 74-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-74\^running
+74\\^running
 (gdb) 
 \*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="3"\},thread-id="1",stopped-threads="all"
 (gdb) 
 -interpreter-exec console kill
-\^done
+\\^done
 (gdb) 
 -break-delete 1
-\^done
+\\^done
 (gdb) 
 75-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
-75\^running
+75\\^running
 (gdb) 
 \*stopped,reason="breakpoint-hit",bkptno="2",disp="keep",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="7"\},thread-id="1",stopped-threads="all"
 (gdb) 
 76-gdb-exit
-76\^exit
+76\\^exit
 """)
     t.cleanup()
 

--- a/test/debugger-mi.py
+++ b/test/debugger-mi.py
@@ -5,16 +5,18 @@
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE.txt or https://www.bfgroup.xyz/b2/LICENSE.txt)
 
-# Test the mi interface for the debugger
+"""
+Test the mi interface for the debugger
+"""
 
 import BoostBuild
 import TestCmd
 import re
 
 def split_stdin_stdout(text):
-    """stdin is all text after the prompt up to and including
-    the next newline.  Everything else is stdout.  stdout
-    may contain regular expressions enclosed in {{}}."""
+    # stdin is all text after the prompt up to and including
+    # the next newline.  Everything else is stdout.  stdout
+    # may contain regular expressions enclosed in {{}}.
     pattern = re.compile(r'(?<=\(gdb\) \n)((?:\d*-.*)\n)')
     stdin = ''.join(re.findall(pattern, text))
     stdout = re.sub(pattern, '', text)
@@ -41,7 +43,6 @@ def test_exec_run():
     t.write("test.jam", """\
         UPDATE ;
     """)
-
     run(t, """\
 =thread-group-added,id="i1"
 (gdb) 
@@ -49,7 +50,7 @@ def test_exec_run():
 =thread-created,id="1",group-id="i1"
 72\\^running
 (gdb) 
-\*stopped,reason="exited-normally"
+\\*stopped,reason="exited-normally"
 (gdb) 
 73-gdb-exit
 73\\^exit
@@ -69,7 +70,7 @@ def test_exit_status():
 72\\^running
 (gdb) 
 
-\*stopped,reason="exited",exit-code="1"
+\\*stopped,reason="exited",exit-code="1"
 (gdb) 
 73-gdb-exit
 73\\^exit
@@ -101,22 +102,22 @@ def test_exec_step():
 =thread-created,id="1",group-id="i1"
 72\\^running
 (gdb) 
-\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="8"\},thread-id="1",stopped-threads="all"
+\\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame={func="f",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="8"},thread-id="1",stopped-threads="all"
 (gdb) 
 1-exec-step
 1\\^running
 (gdb) 
-\*stopped,reason="end-stepping-range",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="3"\},thread-id="1"
+\\*stopped,reason="end-stepping-range",frame={func="g",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="3"},thread-id="1"
 (gdb) 
 2-exec-step
 2\\^running
 (gdb) 
-\*stopped,reason="end-stepping-range",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="4"\},thread-id="1"
+\\*stopped,reason="end-stepping-range",frame={func="g",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="4"},thread-id="1"
 (gdb) 
 3-exec-step
 3\\^running
 (gdb) 
-\*stopped,reason="end-stepping-range",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="9"\},thread-id="1"
+\\*stopped,reason="end-stepping-range",frame={func="f",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="9"},thread-id="1"
 (gdb) 
 73-gdb-exit
 73\\^exit
@@ -148,33 +149,33 @@ def test_exec_next():
 =thread-group-added,id="i1"
 (gdb) 
 -break-insert f
-\\^done,bkpt=\{number="1",type="breakpoint",disp="keep",enabled="y",func="f"\}
+\\^done,bkpt={number="1",type="breakpoint",disp="keep",enabled="y",func="f"}
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
 72\\^running
 (gdb) 
-\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="7"\},thread-id="1",stopped-threads="all"
+\\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame={func="f",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="7"},thread-id="1",stopped-threads="all"
 (gdb) 
 1-exec-next
 1\\^running
 (gdb) 
-\*stopped,reason="end-stepping-range",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="8"\},thread-id="1"
+\\*stopped,reason="end-stepping-range",frame={func="f",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="8"},thread-id="1"
 (gdb) 
 2-exec-next
 2\\^running
 (gdb) 
-\*stopped,reason="end-stepping-range",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="9"\},thread-id="1"
+\\*stopped,reason="end-stepping-range",frame={func="f",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="9"},thread-id="1"
 (gdb) 
 3-exec-next
 3\\^running
 (gdb) 
-\*stopped,reason="end-stepping-range",frame=\{func="h",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="14"\},thread-id="1"
+\\*stopped,reason="end-stepping-range",frame={func="h",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="14"},thread-id="1"
 (gdb) 
 4-exec-next
 4\\^running
 (gdb) 
-\*stopped,reason="end-stepping-range",frame=\{func="module scope",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="17"\},thread-id="1"
+\\*stopped,reason="end-stepping-range",frame={func="module scope",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="17"},thread-id="1"
 (gdb) 
 73-gdb-exit
 73\\^exit
@@ -210,28 +211,28 @@ def test_exec_finish():
 =thread-group-added,id="i1"
 (gdb) 
 -break-insert f
-\\^done,bkpt=\{number="1",type="breakpoint",disp="keep",enabled="y",func="f"\}
+\\^done,bkpt={number="1",type="breakpoint",disp="keep",enabled="y",func="f"}
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
 72\\^running
 (gdb) 
-\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="3"\},thread-id="1",stopped-threads="all"
+\\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame={func="f",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="3"},thread-id="1",stopped-threads="all"
 (gdb) 
 1-exec-finish
 1\\^running
 (gdb) 
-\*stopped,reason="end-stepping-range",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="8"\},thread-id="1"
+\\*stopped,reason="end-stepping-range",frame={func="g",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="8"},thread-id="1"
 (gdb) 
 2-exec-finish
 2\\^running
 (gdb) 
-\*stopped,reason="end-stepping-range",frame=\{func="h",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="14"\},thread-id="1"
+\\*stopped,reason="end-stepping-range",frame={func="h",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="14"},thread-id="1"
 (gdb) 
 3-exec-finish
 3\\^running
 (gdb) 
-\*stopped,reason="end-stepping-range",frame=\{func="module scope",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="21"\},thread-id="1"
+\\*stopped,reason="end-stepping-range",frame={func="module scope",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="21"},thread-id="1"
 (gdb) 
 73-gdb-exit
 73\\^exit
@@ -265,19 +266,19 @@ def test_breakpoints():
 =thread-group-added,id="i1"
 (gdb) 
 -break-insert f
-\\^done,bkpt=\{number="1",type="breakpoint",disp="keep",enabled="y",func="f"\}
+\\^done,bkpt={number="1",type="breakpoint",disp="keep",enabled="y",func="f"}
 (gdb) 
 72-exec-run -ftest.jam
 =thread-created,id="1",group-id="i1"
 72\\^running
 (gdb) 
-\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="3"\},thread-id="1",stopped-threads="all"
+\\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame={func="f",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="3"},thread-id="1",stopped-threads="all"
 (gdb) 
 -interpreter-exec console kill
 \\^done
 (gdb) 
 -break-insert g
-\\^done,bkpt=\{number="2",type="breakpoint",disp="keep",enabled="y",func="g"\}
+\\^done,bkpt={number="2",type="breakpoint",disp="keep",enabled="y",func="g"}
 (gdb) 
 -break-disable 1
 \\^done
@@ -286,7 +287,7 @@ def test_breakpoints():
 =thread-created,id="1",group-id="i1"
 73\\^running
 (gdb) 
-\*stopped,reason="breakpoint-hit",bkptno="2",disp="keep",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="7"\},thread-id="1",stopped-threads="all"
+\\*stopped,reason="breakpoint-hit",bkptno="2",disp="keep",frame={func="g",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="7"},thread-id="1",stopped-threads="all"
 (gdb) 
 -interpreter-exec console kill
 \\^done
@@ -298,7 +299,7 @@ def test_breakpoints():
 =thread-created,id="1",group-id="i1"
 74\\^running
 (gdb) 
-\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame=\{func="f",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="3"\},thread-id="1",stopped-threads="all"
+\\*stopped,reason="breakpoint-hit",bkptno="1",disp="keep",frame={func="f",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="3"},thread-id="1",stopped-threads="all"
 (gdb) 
 -interpreter-exec console kill
 \\^done
@@ -310,7 +311,7 @@ def test_breakpoints():
 =thread-created,id="1",group-id="i1"
 75\\^running
 (gdb) 
-\*stopped,reason="breakpoint-hit",bkptno="2",disp="keep",frame=\{func="g",args=\[\],file="test.jam",fullname="{{.+}}test.jam",line="7"\},thread-id="1",stopped-threads="all"
+\\*stopped,reason="breakpoint-hit",bkptno="2",disp="keep",frame={func="g",args=\\[\\],file="test.jam",fullname="{{.+}}test.jam",line="7"},thread-id="1",stopped-threads="all"
 (gdb) 
 76-gdb-exit
 76\\^exit


### PR DESCRIPTION
+ direct definition of `pattern` in `split_stdin_stdout` was a good idea
+ minor `outside_pattern` adjustment
+ `escape_line` now escapes prompt only, for more readability of diff output in case of error
+ simplified `BoostBuild.Tester` init
+ escape added on test data where needed
+ better regexps hardcoded in test data, mainly `.*` -> `.+`
+ optimized `TestCmd.match_re`, use of `re.match` instead of forcing regex compilation, since Python `re.match` use a cache to remember already compiled expressions do not need to recompile `"\(gdb\) $"` any time

René, I'm sorry but I didn't have time to add them to #574 