### PR TITLE
fixed builtin SUBST rule (fix #571)

### DIFF
--- a/doc/src/history.adoc
+++ b/doc/src/history.adoc
@@ -39,6 +39,8 @@
   -- _Paolo Pastori_
 * Fix GLOB_ARCHIVE builtin rule to work with BSD archive (ar).
   -- _Paolo Pastori_
+* Fix SUBST builtin rule eating chars in replacement, test added.
+  -- _Paolo Pastori_
 
 == Version 5.4.2
 

--- a/src/engine/builtins.cpp
+++ b/src/engine/builtins.cpp
@@ -1013,18 +1013,18 @@ LIST * builtin_subst( FRAME * frame, int flags )
 
             while ( ( subst = list_next( subst ) ) != end )
             {
-#define BUFLEN 4096
-                char buf[ BUFLEN + 1 ];
+#define BUFLEN 4094
+                char buf[ BUFLEN + 2 ];
                 char const * in = object_str( list_item( subst ) );
                 char * out = buf;
 
                 for ( ; *in && out < buf + BUFLEN; ++in )
                 {
+                    /* check for placeholders "\\N" and "$N" */
                     if ( *in == '\\' || *in == '$' )
                     {
+                        char plcc = *in;
                         ++in;
-                        if ( *in == 0 )
-                            break;
                         if ( *in >= '0' && *in <= '9' )
                         {
                             unsigned int const n = *in - '0';
@@ -1035,6 +1035,15 @@ LIST * builtin_subst( FRAME * frame, int flags )
                                 : remaining;
                             memcpy( out, re_i[ n ].begin(), len );
                             out += len;
+                            continue;
+                        }
+                        *out++ = plcc;
+                        if ( *in == 0 )
+                            break;
+                        /* reparse the next character if can be a placeholder */
+                        if ( *in == '\\' || *in == '$' )
+                        {
+                            --in;
                             continue;
                         }
                         /* fall through and copy the next character */

--- a/test/match_list.py
+++ b/test/match_list.py
@@ -5,7 +5,7 @@
 # (See accompanying file LICENSE.txt or https://www.bfgroup.xyz/b2/LICENSE.txt)
 
 # List of tested regexps. Each tuple contains the pattern,
-# the value used for the test, and the expected result (do not use [] here).
+# the value used for the test, and the expected result (do not use [] here.)
 # Any test is processed by an instruction such as
 #
 # ECHO [ MATCH <pattern> : <value> ] ;
@@ -83,7 +83,7 @@ trials = [
 testln = []
 exptln = []
 for n, c in enumerate(trials):
-    testln.append('ECHO {} [ MATCH {} : {} ] ;'.format(n, c[0], c[1]))
+    testln.append('ECHO {} [ MATCH {} : {} ] ;'.format(n, *c))
     exptln.append('{} {}'.format(n, c[2]) if c[2] else str(n))
 testln.append('EXIT : 0 ;\n')
 exptln.append('\n')
@@ -91,8 +91,11 @@ exptln.append('\n')
 import BoostBuild
 
 t = BoostBuild.Tester(pass_toolset=False)
-t.write('Jamroot', '\n'.join(testln))
-t.run_build_system()
-t.expect_output_lines('\n'.join(exptln))
-t.expect_nothing_more()
+
+t.run_build_system(
+    ["-d0", "-f-"],
+    stdin='\n'.join(testln),
+    stdout='\n'.join(exptln)
+)
+
 t.cleanup()

--- a/test/subst_list.py
+++ b/test/subst_list.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Paolo Pastori
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE.txt or https://www.bfgroup.xyz/b2/LICENSE.txt)
+
+# List of tests. Each tuple contains the value used for the test,
+# the pattern, the replacement, and the expected result (do not use [] here.)
+# Any test is processed by an instruction such as
+#
+# ECHO [ SUBST <value> <pattern> <replacement> ] ;
+#
+# fell free to add more test cases...
+
+# remember to use raw strings to avoid surprises with escaping
+trials = [
+    (r'""', r'""', r'""', r''),
+    # no matching value
+    (r'aeio', r'u', r'xyz', r''),
+    # matched value
+    (r'aeio', r'i', r'xyz', r'xyz'),
+    # \\0 placeholder in replacement
+    (r'aeio', r'i', r'\\0', r'i'),
+    # placeholders in replacement
+    (r'"234.15 $"', r'"([0-9.]+) (.)"', r'"currency: $2, amount: \\1"', r'currency: $, amount: 234.15'),
+    # special chars in replacement
+    (r'"total: 100"', r'"total: ([0-9]+)"', r'"$$1"', r'$100'), # NOTE: $$ in replacement does not eat $
+    (r'"total: 3"', r'"^total: ([0-9]+)$"', r'"$\\1"', r'$3'), # NOTE: $\ in replacement does not eat \
+    (r'/etc/doc', r'^/etc/(.+)$', r'"C:\\$1"', r'C:\doc'), # NOTE: \$ in replacement does not eat $
+    (r'/etc/doc', r'^/etc/(.+)$', r'"C:\\\\1"', r'C:\doc'), # NOTE: \\ in replacement does not eat \
+]
+
+# Do not change code below !
+
+testln = []
+exptln = []
+for n, c in enumerate(trials):
+    testln.append('ECHO {} [ SUBST {} {} {} ] ;'.format(n, *c))
+    exptln.append('{} {}'.format(n, c[3]) if c[3] else str(n))
+testln.append('EXIT : 0 ;\n')
+exptln.append('\n')
+
+import BoostBuild
+
+t = BoostBuild.Tester(pass_toolset=False)
+
+t.run_build_system(
+    ["-d0", "-f-"],
+    stdin='\n'.join(testln),
+    stdout='\n'.join(exptln)
+)
+
+t.cleanup()

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -462,6 +462,7 @@ tests = [
     "stage",
     "standalone",
     "static_and_shared_library",
+    "subst_list",
     "suffix",
     "tag",
     "test_rc",


### PR DESCRIPTION
+ does not eat anymore `\` and `$` chars in replacement
+ added `test/subst_list.py`
+ optimized `test/match_list.py` (3 times faster)
