### PR TITLE
binding benchmarks (experimental, see #590)

### DIFF
--- a/src/engine/bindjam.cpp
+++ b/src/engine/bindjam.cpp
@@ -35,6 +35,7 @@ Distributed under the Boost Software License, Version 1.0.
 #include "mod_string.h"
 #include "mod_sysinfo.h"
 #include "mod_version.h"
+#include "mod_bind_benchmark.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -850,7 +851,8 @@ void bind_jam(FRAME * f)
 		.bind(version_module())
 		.bind(db_module())
 		.bind(command_db_module())
-		.bind(b2::args::args_module());
+		.bind(b2::args::args_module())
+		.bind(benchmark_module());
 }
 
 }} // namespace b2::jam

--- a/src/engine/build.bat
+++ b/src/engine/build.bat
@@ -195,6 +195,7 @@ set B2_SOURCES=%B2_SOURCES% mod_string.cpp
 set B2_SOURCES=%B2_SOURCES% mod_summary.cpp
 set B2_SOURCES=%B2_SOURCES% mod_sysinfo.cpp
 set B2_SOURCES=%B2_SOURCES% mod_version.cpp
+set B2_SOURCES=%B2_SOURCES% mod_bind_benchmark.cpp
 
 set B2_CXXFLAGS=%B2_CXXFLAGS% -DNDEBUG
 

--- a/src/engine/build.sh
+++ b/src/engine/build.sh
@@ -486,6 +486,7 @@ mod_string.cpp \
 mod_summary.cpp \
 mod_sysinfo.cpp \
 mod_version.cpp \
+mod_bind_benchmark.cpp \
  "
 
     if test_true ${B2_DEBUG_OPT} ; then B2_CXXFLAGS="${B2_CXXFLAGS_DEBUG}"

--- a/src/engine/builtins.cpp
+++ b/src/engine/builtins.cpp
@@ -511,6 +511,8 @@ void load_builtins()
     init_property_set();
     init_sequence();
     init_order();
+    void init_benchmark();
+    init_benchmark();
 }
 
 

--- a/src/engine/mod_bind_benchmark.cpp
+++ b/src/engine/mod_bind_benchmark.cpp
@@ -18,7 +18,7 @@ Distributed under the Boost Software License, Version 1.0.
 template<unsigned shift>
 struct WatchedCounter
 {
-    static_assert(shift < 32);
+    static_assert(shift < 32, "");
     static constexpr size_t mask = 1 << shift;
     bool last_masked = false;
     size_t counter = 0;
@@ -26,7 +26,7 @@ struct WatchedCounter
     size_t exit_count;
 
     /*
-     * Exit program after n reports.
+     * Exit program after num reports.
      */
     WatchedCounter(unsigned num = 1) : exit_count(mask * num) { t0 = clock(); }
     void tick()

--- a/src/engine/mod_bind_benchmark.cpp
+++ b/src/engine/mod_bind_benchmark.cpp
@@ -28,7 +28,7 @@ struct WatchedCounter
     /*
      * Exit program after num reports.
      */
-    WatchedCounter(unsigned num = 1) : exit_count(mask * num) { t0 = clock(); }
+    WatchedCounter(unsigned num = 1) : exit_count(num << shift) { t0 = clock(); }
     void tick()
     {
         if (bool(++counter & mask) != last_masked)

--- a/src/engine/mod_bind_benchmark.cpp
+++ b/src/engine/mod_bind_benchmark.cpp
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 Paolo Pastori
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE.txt or https://www.bfgroup.xyz/b2/LICENSE.txt)
+*/
+
+#include "startup.h"
+#include "native.h"
+#include "output.h"
+
+#include <ctime>
+#include <cstdlib>
+
+
+/*
+ * Report collected data on stderr every 1<<shift tick() calls.
+ */
+template<unsigned shift>
+struct WatchedCounter
+{
+    static_assert(shift < 32);
+    static constexpr size_t mask = 1 << shift;
+    bool last_masked = false;
+    size_t counter = 0;
+    clock_t t0;
+    size_t exit_count;
+
+    /*
+     * Exit program after n reports.
+     */
+    WatchedCounter(unsigned num = 1) : exit_count(mask * num) { t0 = clock(); }
+    void tick()
+    {
+        if (bool(++counter & mask) != last_masked)
+        {
+            last_masked = !last_masked;
+            clock_t t1 = clock();
+            double dur = 1000.0 * (t1 - t0) / CLOCKS_PER_SEC;
+            err_printf("%ld\t%.3f\n", counter, dur);
+        }
+        if (counter == exit_count) b2::clean_exit(EXIT_SUCCESS);
+    }
+};
+
+
+/*
+ * Legacy binding style.
+ */
+LIST * native_timed(FRAME * frame, int flags)
+{
+    //out_puts("LEGACY TIMED\n");
+    static WatchedCounter<13> wc(2);
+    wc.tick();
+    return L0;
+}
+
+void init_benchmark()
+{
+    //char const * args[] = { "any", "*", 0 }; // only used to check for call syntax
+    char const * * args = nullptr; // do not care of args
+    declare_native_rule(
+        "benchmark",
+        "timed",
+        args,
+        native_timed,
+        1
+    );
+}
+
+
+/*
+ * New binding style.
+ */
+namespace b2 {
+
+// NOTE: returning void seems slower
+//void timed_no_args()
+value_ref timed_no_args()
+{
+    //out_puts("NEW BINDING TIMED\n");
+    static WatchedCounter<13> wc(2);
+    wc.tick();
+    return value_ref();
+}
+
+value_ref timed_any_args(list_cref args)
+{
+    static WatchedCounter<13> wc(2);
+    wc.tick();
+    return value_ref();
+}
+
+} // namespace b2

--- a/src/engine/mod_bind_benchmark.cpp
+++ b/src/engine/mod_bind_benchmark.cpp
@@ -28,7 +28,7 @@ struct WatchedCounter
     /*
      * Exit program after num reports.
      */
-    WatchedCounter(unsigned num = 1) : exit_count(num << shift) { t0 = clock(); }
+    WatchedCounter(size_t num = 1) : exit_count(num << shift) { t0 = clock(); }
     void tick()
     {
         if (bool(++counter & mask) != last_masked)

--- a/src/engine/mod_bind_benchmark.h
+++ b/src/engine/mod_bind_benchmark.h
@@ -1,0 +1,28 @@
+/*
+Copyright 2026 Paolo Pastori
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE.txt or https://www.bfgroup.xyz/b2/LICENSE.txt)
+*/
+
+namespace b2 {
+
+//void timed_no_args();
+value_ref timed_no_args();
+value_ref timed_any_args(list_cref args);
+
+/*
+ * New binding style.
+ */
+struct benchmark_module : b2::bind::module_<benchmark_module>
+{
+	const char * module_name = "benchmark";
+
+	template <class Binder>
+	void def(Binder & binder)
+	{
+		//binder.def(&b2::timed_no_args, "timed");
+		binder.def(&b2::timed_any_args, "timed");
+		binder.loaded();
+	}
+};
+} // namespace b2


### PR DESCRIPTION
Use with `legacy.jam` (e.g. `b2 -flegacy.jam`)
```
NATIVE_RULE benchmark : timed ;
IMPORT benchmark : timed : : benchmark.timed ;
while true { benchmark.timed qwerty ; }
```
or with `Jamroot`
```
import benchmark ;
while true { benchmark.timed qwerty ; }
```

see #590 