### PR TITLE
build/property-set.jam review

### DIFF
--- a/src/build/property-set.jam
+++ b/src/build/property-set.jam
@@ -5,14 +5,11 @@
 # https://www.bfgroup.xyz/b2/LICENSE.txt)
 
 import "class" : new ;
-import feature ;
 import indirect ;
 import path ;
 import project ;
 import property ;
-import sequence ;
-import set ;
-import option ;
+import set : difference : set.difference ;
 import args ;
 
 # Class for storing a set of properties.
@@ -29,19 +26,16 @@ import args ;
 #   It is possible to get a list of properties belonging to each category as
 # well as a list of properties with a specific attribute.
 #
-#   Several operations, like and refine and as-path are provided. They all use
+#   Several operations, like refine and as-path are provided. They all use
 # caching whenever possible.
 #
 class property-set
 {
-    import errors ;
     import feature ;
-    import modules ;
-    import path ;
+    import path : join : path.join ;
     import property ;
     import property-set ;
-    import set ;
-    import sequence ;
+    import sequence : transform : sequence.transform ;
 
     rule __init__ ( raw-properties * )
     {
@@ -51,6 +45,7 @@ class property-set
         {
             if ! $(p:G)
             {
+                import errors ;
                 errors.error "Invalid property: '$(p)'" ;
             }
         }
@@ -335,6 +330,11 @@ class property-set
         return $($(feature)) ;
     }
 
+    if [ HAS_NATIVE_RULE class@property-set : get : 1 ]
+    {
+        NATIVE_RULE class@property-set : get ;
+    }
+
     # Returns true if the property-set contains all the
     # specified properties.
     #
@@ -355,6 +355,11 @@ class property-set
         {
             return true ;
         }
+    }
+
+    if [ HAS_NATIVE_RULE class@property-set : contains-features : 1 ]
+    {
+        NATIVE_RULE class@property-set : contains-features ;
     }
 
     # private
@@ -429,7 +434,9 @@ class property-set
             # characters as well, e.g. free or indirect properties. Indirect
             # properties for example contain a full Jamfile path in their value
             # which on Windows file systems contains ':' as the drive separator.
-            if ( [ MATCH "(:)" : $(p:G=) ] && ! ( free in [ feature.attributes $(p:G) ] ) ) || $(p:G) = <conditional>
+            if ( [ MATCH "(:)" : $(p:G=) ]
+                 && ! ( free in [ feature.attributes $(p:G) ] )
+               ) || $(p:G) = <conditional>
             {
                 self.conditional += $(p) ;
             }
@@ -442,13 +449,12 @@ class property-set
     }
 }
 
-# Creates a new 'property-set' instance for the given raw properties or returns
-# an already existing ones.
-#
+# Creates a new 'property-set' instance for the given raw properties
+# or returns an already existing ones.
+#|
 rule create ( raw-properties * )
 {
-    raw-properties = [ sequence.unique
-        [ sequence.insertion-sort $(raw-properties) ] ] ;
+    raw-properties = [ sequence.unique [ SORT $(raw-properties) ] ] ;
 
     local key = $(raw-properties:J=-:E=) ;
 
@@ -458,17 +464,8 @@ rule create ( raw-properties * )
     }
     return $(.ps.$(key)) ;
 }
+|#
 NATIVE_RULE property-set : create ;
-
-if [ HAS_NATIVE_RULE class@property-set : get : 1 ]
-{
-    NATIVE_RULE class@property-set : get ;
-}
-
-if [ HAS_NATIVE_RULE class@property-set : contains-features : 1 ]
-{
-    NATIVE_RULE class@property-set : contains-features ;
-}
 
 # Creates a new 'property-set' instance after checking that all properties are
 # valid and converting implicit properties into gristed form.
@@ -486,7 +483,10 @@ rule create-with-validation ( raw-properties * )
 rule create-from-user-input ( raw-properties * : jamfile-module location )
 {
     local project-id = [ project.attribute $(jamfile-module) id ] ;
-    project-id ?= [ path.root $(location) [ path.pwd ] ] ;
+    if ! $(project-id)
+    {
+        project-id = [ path.root $(location) [ path.pwd ] ] ;
+    }
     return [ property-set.create [ property.translate $(raw-properties)
         : $(project-id) : $(location) : $(jamfile-module) ] ] ;
 }


### PR DESCRIPTION
+ removed unused imports at module/class level
+ adjusted imports for cases where just single rule was used
+ moved `NATIVE_RULE` declaration right below Jam rules
+ clearer condition in `init-conditional` method
+ leave `create` rule in comment for documentation purpose
+ replace `?=` (which does not short-circuit) with `if` in `create-from-user-input` rule
