### PR TITLE
Fixed compiler warnings in the c++ build

### DIFF
--- a/src/engine/bindjam.cpp
+++ b/src/engine/bindjam.cpp
@@ -560,7 +560,7 @@ struct jam_arg_spec_count_sum<X, A...>
 	//     = X::count + jam_arg_spec_count_sum<A...>::value;
 	enum : std::size_t
 	{
-		value = X::count + jam_arg_spec_count_sum<A...>::value
+		value = static_cast<std::size_t>(X::count) + static_cast<std::size_t>(jam_arg_spec_count_sum<A...>::value)
 	};
 };
 

--- a/src/engine/value.h
+++ b/src/engine/value.h
@@ -131,12 +131,15 @@ struct value_ref
 	inline bool operator==(value_ptr b) const { return val->equal_to(*b); }
 	inline bool operator==(const char * v) const
 	{
-		return (*this) == value_ref(v);
+		return val->equal_to(*value_ref(v));
 	}
-	template <typename T>
-	inline bool operator!=(T v) const
+	inline bool operator!=(value_ptr b) const
 	{
-		return !((*this) == v);
+		return !(val->equal_to(*b));
+	}
+	inline bool operator!=(const char * v) const
+	{
+		return !(val->equal_to(*value_ref(v)));
 	}
 	inline value_ptr operator->() const { return val; }
 	inline value & operator*() const { return *val; }


### PR DESCRIPTION
## Proposed changes

When I was building this in my gentoo system, I was bombarded with compiler warnings that looked scary at first glance. This removes these warnings so that installs look less chaotic. One group of warnings was complaining that the order in which == operators were declared was undefined, so making all four equals/not equals operations in the value_ref class depend on a single function was fragile. To fix this, I implemented all 4 explicitly using the equal_to function. The other is another that enums need to be explicitly static_casted since direct adding between two different enum types is deprecated, now the only warning is [about calling free on a nonheap object in a yyparse function](https://github.com/bfgroup/b2/issues/366), which from a cursory glance is the compiler not realizing that it only gets freed if it is a heap object

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)