### PR TITLE
[python] Do not link pthread for Android by default

### DIFF
--- a/src/tools/python.jam
+++ b/src/tools/python.jam
@@ -705,6 +705,7 @@ local rule system-library-dependencies ( target-os )
         case darwin : return ;
         case windows : return ;
         case haiku : return ;
+        case android : return ;
 
         case hpux : return  <library>rt ;
         case *bsd : return  <library>pthread <toolset>gcc:<library>util ;


### PR DESCRIPTION
## Proposed changes

Greetings! :wave: 

When cross-building from Linux x86_64 to Android armv8, and using Python configuration, during the linkage stage, the following error is produced:

```
clang-linux.link.dll /tmp/boost-1.91.0/install/lib/libboost_python312.so
ld.lld: error: unable to find library -lpthread
clang++: error: linker command failed with exit code 1 (use -v to see invocation)

    "/opt/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang++"   -Wl,-rpath-link -Wl,"/tmp/tmp.mYMUm8HugX/boost_1_91_0/bin.v2/libs/container/build/clang-linux-21/release/arm_64/target-os-android/threading-multi/visibility-hidden" -Wl,-rpath-link -Wl,"/tmp/tmp.mYMUm8HugX/boost_1_91_0/bin.v2/libs/graph/build/clang-linux-21/release/arm_64/target-os-android/threading-multi/visibility-hidden" -Wl,-rpath-link -Wl,"/tmp/tmp.mYMUm8HugX/boost_1_91_0/bin.v2/libs/container/build/clang-linux-21/release/arm_64/target-os-android/threading-multi/visibility-hidden" -Wl,-rpath-link -Wl,"/tmp/tmp.mYMUm8HugX/boost_1_91_0/bin.v2/libs/graph/build/clang-linux-21/release/arm_64/target-os-android/threading-multi/visibility-hidden"  -o "/tmp/boost-1.91.0/install/lib/libboost_python312.so" -Wl,-soname -Wl,"libboost_python312.so" -shared -Wl,--start-group "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/list.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/long.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/dict.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/tuple.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/str.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/slice.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/converter/from_python.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/converter/registry.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/converter/type_id.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/object/enum.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/object/class.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/object/function.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/object/inheritance.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/object/life_support.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/object/pickle_support.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/errors.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/module.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/converter/builtin_converters.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/converter/arg_to_python_base.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/object/iterator.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/object/stl_iterator.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/object_protocol.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/object_operators.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/wrapper.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/import.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/exec.o" "bin.v2/libs/python/build/clang-linux-21/release/arm_64/python-3.12/target-os-android/threading-multi/visibility-hidden/object/function_doc_signature.o" "bin.v2/libs/graph/build/clang-linux-21/release/arm_64/target-os-android/threading-multi/visibility-hidden/libboost_graph.so" "bin.v2/libs/container/build/clang-linux-21/release/arm_64/target-os-android/threading-multi/visibility-hidden/libboost_container.so"  -Wl,-Bstatic  -Wl,-Bdynamic -ldl -lpthread -Wl,--end-group -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -m64

...failed clang-linux.link.dll /tmp/boost-1.91.0/install/lib/libboost_python312.so...
```

You can see the full build log here: [boost-1.91.0-linux-amd64-android-armv8.log](https://github.com/user-attachments/files/29958853/boost-1.91.0-linux-amd64-android-armv8.log)

The error occurred when trying to build Boost 1.91.0, using Boost.Python, because the [python.jam](https://github.com/bfgroup/b2/blob/main/src/tools/python.jam#L714) falls back to using `pthread` by default when the target-os is not mapped. In this case, we are using `<target-os>android` which is not there.

For Android specifically, linking `pthread` isn't needed because it's already part of the `libc` as a built-in feature. References:

- https://android.googlesource.com/platform/bionic/+/master/docs/status.md#libc
- https://developer.android.google.cn/ndk/guides/stable_apis

This PR adds a new condition to filter out `android` from adding `pthread` when linking. Once using this new patch, I can build the previous scenario with success:  [boost-1.91.0-linux-amd64-android-armv8-patched.log](https://github.com/user-attachments/files/29958891/boost-1.91.0-linux-amd64-android-armv8-patched.log)

#### Steps to Reproduce

```
wget https://archives.boost.io/release/1.91.0/source/boost_1_91_0.tar.bz2
tar jxf boost_1_91_0.tar.bz2 && cd boost_1_91_0/
./bootstrap.sh --with-toolset=gcc --prefix=/tmp/boost-1.91.0/install
./b2 install abi=aapcs address-model=64 --prefix=/tmp/boost-1.91.0/install -j1 -q toolset=clang --layout=system threading=multi link=shared variant=release target-os=android architecture=arm binary-format=elf address-model=64 --user-config=user-config.jam --with-python
```

My `user-config.jam` looks like:

```
using python : 3.12 : "/opt/pyenv/versions/3.12.4" : : : <target-os>android ;
using clang : : /opt/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang++ ;
```

#### Environment
* B2: 5.4.2 - Provided with Boost 1.91.0
* Boost: 1.91.0
* Host OS: Linux (Ubuntu 24.04)
* Host Architecture: x86_64
* Target OS: Android
* Target Architecture: ARMv8
* NDK: version r29
* Compiler:
    * Android (13989888, +pgo, +bolt, +lto, +mlgo, based on r563880c) clang version 21.0.0 (https://android.googlesource.com/toolchain/llvm-project 5e96669f06077099aa41290cdb4c5e6fa0f59349)
    * Target: aarch64-unknown-linux-android21
    * Thread model: posix
    * InstalledDir: /opt/android-ndk-r29/toolchains/llvm/prebuilt/linux-x86_64/bin

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [ ] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [ ] I checked that tests pass locally with my changes
- [x] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

Let me know if you need more information or new tests to cover this reported case. Regards! 
