### PR TITLE
Exclude iphone and appletv from rpath-link when linking with clang-darwin

### DIFF
--- a/src/tools/gcc.jam
+++ b/src/tools/gcc.jam
@@ -940,7 +940,7 @@ toolset.flags gcc.link OPTIONS <coverage>on : --coverage ;
         -Wl,--start-group ;
     toolset.flags gcc.link END-GROUP <target-os>$(generic-os) : -Wl,--end-group ;
 
-    local rpath-os = [ set.difference $(all-os) : aix darwin vxworks solaris osf hpux windows ] ;
+    local rpath-os = [ set.difference $(all-os) : aix darwin vxworks solaris osf hpux windows iphone appletv ] ;
     toolset.flags gcc.link RPATH <target-os>$(rpath-os) : <dll-path> ;
     toolset.flags gcc.link RPATH_OPTION <target-os>$(rpath-os) : -rpath ;
     toolset.flags gcc.link RPATH_LINK <target-os>$(rpath-os) : <xdll-path> ;


### PR DESCRIPTION
## Proposed changes

Hello! 👋 

When cross-building Boost 1.91.0 on macOS to iOS (iphone), and linking a shared library that has a transitive shared-library dependency (e.g. Boost.ProgramOptions, which links against Boost.Container), the following error is produced:

```
clang-darwin.link.dll .../libboost_program_options.so.1.91.0
    ld: unknown options: -rpath-link -rpath-link
    clang++: error: linker command failed with exit code 1 (use -v to see invocation)
        "clang++"   -Wl,-rpath-link -Wl,"..." -Wl,-rpath-link -Wl,"..."  -o "...libboost_program_options.so.1.91.0"  -shared  ...
    ...failed clang-darwin.link.dll .../libboost_program_options.so.1.91.0...
```

You can see the full build log here: [boost-1.91.0-darwin-iphone-shared.log](https://github.com/user-attachments/files/29999695/boost-1.91.0-darwin-iphone-shared.log)

The toolset `clang-darwin` falls back to `gcc.jam`, so `link.dll` embeds `-Wl,-rpath-link` whenever `RPATH_LINK` is set for the current `<target-os>`. 

The good thing is `gcc.jam` already excludes `darwin` from that set, so we don't see it when building for regular darwin:

https://github.com/bfgroup/b2/blob/5.5.2/src/tools/gcc.jam#L943

```
local rpath-os = [ set.difference $(all-os) : aix darwin vxworks solaris osf hpux windows ] ;
toolset.flags gcc.link RPATH <target-os>$(rpath-os) : <dll-path> ;
toolset.flags gcc.link RPATH_OPTION <target-os>$(rpath-os) : -rpath ;
toolset.flags gcc.link RPATH_LINK <target-os>$(rpath-os) : <xdll-path> ;
```

But it misses `iphone` and `appletv`. 

Apple's linker invoked via `clang++ -isysroot .../iPhoneOS*.sdk -arch arm64 ...` does not support `-rpath-link` because it's a GNU flag, not valid for Mach-O targets. References:

- https://linux.die.net/man/1/ld
- https://leopard-adc.pepas.com/documentation/Darwin/Reference/ManPages/man1/ld.1.html

-----

This PR makes `rpath-os` also exclude `iphone` and `appletv`, matching the existing `generic-os` treatment right above it, so `RPATH_LINK` is never set for Apple mobile targets, same as it's already not set for `darwin`.

After applying this patch, I can build Boost 1.91.0 with success: [boost-1.91.0-darwin-iphone-shared-patched.log](https://github.com/user-attachments/files/30000274/boost-1.91.0-darwin-iphone-shared-patched.log)

#### Steps to Reproduce

```
wget https://archives.boost.io/release/1.91.0/source/boost_1_91_0.tar.bz2
tar jxf boost_1_91_0.tar.bz2 && cd boost_1_91_0/
./bootstrap.sh
./b2 install --prefix=/tmp/boost-install-ios --user-config=user-config.jam toolset=clang target-os=iphone architecture=arm address-model=64 abi=aapcs link=shared --with-program_options -q -d2 --no-cmake-config
```

The `user-config.jam` looks like:

```
using clang : : clang++ :
    <cflags>"-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.5.sdk -arch arm64 -mios-version-min=26.5"
    <cxxflags>"-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.5.sdk -arch arm64 -mios-version-min=26.5"
    <linkflags>"-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.5.sdk -arch arm64 -mios-version-min=26.5" ;
```

#### Environment

- B2: 5.4.2 -- Provided with Boost 1.91.0
- Boost: 1.91.0
- Host OS: macOS 26.5 (arm64)
- Target OS: iOS 26.5
- Target Architecture: ARMv8 (arm64)
- Compiler: Apple clang version 21.0.0 (clang-2100.1.1.101)

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [ ] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)

## Further comments

Same PR class as #602 and #603. Let me know if you'd like a regression test added for this case. Regards!
