### PR TITLE
Fix using ccache with clang-linux toolset 

### DIFF
--- a/src/tools/clang-linux.jam
+++ b/src/tools/clang-linux.jam
@@ -110,7 +110,7 @@ rule init ( version ? :  command * : options * ) {
     }
   if ! $(archiver)
     {
-    local bin = [ common.get-absolute-tool-path $(command) ] ;
+    local bin = [ common.get-absolute-tool-path $(command[-1]) ] ;
     archiver = [ common.get-invocation-command-nodefault clang-linux : llvm-ar : : $(bin) : search-path ] ;
     }
   toolset.flags clang-linux.archive .AR $(condition) : $(archiver[1]) ;

--- a/test/toolset-mock/project-config.jam
+++ b/test/toolset-mock/project-config.jam
@@ -27,6 +27,8 @@ using darwin : 4.2.1 : $(PYTHON) $(here)/src/darwin-4.2.1.py
 
 using clang-darwin  : 3.9.0 : $(PYTHON) $(here)/src/clang-3.9.0-darwin.py : $(ar) ;
 using clang-linux   : 3.9.0 : $(PYTHON) $(here)/src/clang-linux-3.9.0.py : $(ar) ;
+# Let clang-linux auto-deduce the archiver
+using clang-linux   : 3.9.1 : $(PYTHON) $(here)/src/clang-linux-3.9.0.py ;
 using clang-vxworks : 4.0.1 : $(PYTHON) $(here)/src/clang-vxworks-4.0.1.py : $(ar) ;
 using intel-darwin  : 10.2  : $(PYTHON) $(here)/src/intel-darwin-10.2.py : $(ar) ;
 

--- a/test/toolset_clang_linux.py
+++ b/test/toolset_clang_linux.py
@@ -27,3 +27,6 @@ test_toolset("clang-linux", "3.9.0", [
     ["target-os=windows", "link=static"],
     ["target-os=windows", "architecture=x86", "address-model=32"]
     ])
+
+# Auto-deduced ar
+test_toolset("clang-linux", "3.9.1", [["target-os=linux"]])


### PR DESCRIPTION
When using ccache with `using clang : : ccache clang++-3.6 ;` then `common.get-absolute-tool-path` fails.

Use the last element as done for gcc

## Proposed changes

This fixes the error for the ccache use case above:
> error: rule common.get-absolute-tool-path ( command )
 error: called with: ( ccache clang++-3.6 )
 error: extra argument clang++-3.6

It fixes a regression introduced with https://github.com/bfgroup/b2/commit/be8700f32dd84ab9e95366bf42934fd9674c3a42

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

- [x] I searched the [discussions](https://github.com/bfgroup/b2/discussions)
- [x] I searched the closed and open [issues](https://github.com/bfgroup/b2/issues?q=is%3Aissue)
- [x] I read the [contribution guidelines](https://github.com/bfgroup/b2/blob/main/CONTRIBUTING.adoc)
- [x] I added myself to the copyright attributions for significant changes
- [x] I checked that tests pass locally with my changes
- [x] I added tests that prove my fix is effective or that my feature works
- [ ] I added necessary documentation (if appropriate)


The test I added is actually quite crude, but does the job. It would likely be better if https://github.com/bfgroup/b2/commit/be8700f32dd84ab9e95366bf42934fd9674c3a42 added a test to check llvm-ar is actually picked up but I didn't went to deep into how to do that.

A (mostly generated) test case in case you'd rather use that instead:

```
import BoostBuild
import sys

t = BoostBuild.Tester()
t.set_tree("toolset-mock")

# Overwrite project-config.jam to configure clang-linux WITHOUT <archiver>.
# The PYTHON command used there makes this similar to uses of ccache: "ccache clang-3.9"
# Omitting <archiver> triggers the archiver auto-detection that calls get-absolute-tool-path,
# which should work in this case too.
t.write("project-config.jam", """\
import os ;
import toolset ;

path-constant here : . ;

local PYTHON = [ os.environ PYTHON_CMD ] ;

using clang-linux : 3.9.0 : $(PYTHON) $(here)/src/clang-linux-3.9.0.py ;
""")

t.run_build_system(subdir="src")
default_target_os = t.read("src/bin/target-os.txt").strip()

t.set_toolset("clang-linux-3.9.0", "linux")
# Build with link=shared (archiver is not needed for shared libraries).
# Without the fix, init fails with "extra argument" before the build starts.
properties = ["link=shared", "target-os=linux"]

t.run_build_system([
    "--user-config=",
    "-sPYTHON_CMD=%s" % sys.executable,
] + properties)

# Verify the shared library and executable were built.
path_prefix = "bin/clang-linux-*/debug"
if default_target_os != "linux":
    path_prefix += "/target-os-linux"

t.expect_addition("%s/l1.dll" % path_prefix)
t.expect_addition("%s/test.exe" % path_prefix)

t.cleanup()
```
